### PR TITLE
Fix serialization and licenseInfoInFiles name

### DIFF
--- a/src/DemaConsulting.SpdxModel/IO/Spdx2JsonSerializer.cs
+++ b/src/DemaConsulting.SpdxModel/IO/Spdx2JsonSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 
 namespace DemaConsulting.SpdxModel.IO;
 
@@ -20,7 +21,11 @@ public static class Spdx2JsonSerializer
 
         // Convert to string
         return json.ToJsonString(
-            new JsonSerializerOptions { WriteIndented = true });
+            new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+            });
     }
 
     /// <summary>
@@ -149,7 +154,7 @@ public static class Spdx2JsonSerializer
         EmitOptionalStrings(json, "fileTypes", file.FileTypes.Select(SpdxFileTypeExtensions.ToText).ToArray());
         json["checksums"] = SerializeChecksums(file.Checksums);
         EmitOptionalString(json, "licenseConcluded", file.LicenseConcluded);
-        EmitOptionalStrings(json, "licenseInfoInFile", file.LicenseInfoInFiles);
+        EmitOptionalStrings(json, "licenseInfoInFiles", file.LicenseInfoInFiles);
         EmitOptionalString(json, "licenseComments", file.LicenseComments);
         EmitOptionalString(json, "copyrightText", file.Copyright);
         EmitOptionalString(json, "comment", file.Comment);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeFile.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeFile.cs
@@ -63,7 +63,7 @@ public class Spdx2JsonSerializeFile
         Assert.AreEqual("2fd4e1c67a2d28f123849ee1bb76e7391b93eb12",
             json["checksums"]?[0]?["checksumValue"]?.ToString());
         Assert.AreEqual("Apache-2.0", json["licenseConcluded"]?.ToString());
-        Assert.AreEqual("Apache-2.0", json["licenseInfoInFile"]?[0]?.ToString());
+        Assert.AreEqual("Apache-2.0", json["licenseInfoInFiles"]?[0]?.ToString());
         Assert.AreEqual("This license is used by Jena", json["licenseComments"]?.ToString());
         Assert.AreEqual("Copyright 2010, 2011 Source Auditor Inc.", json["copyrightText"]?.ToString());
         Assert.AreEqual("This file is a sample DOAP file", json["comment"]?.ToString());
@@ -144,7 +144,7 @@ public class Spdx2JsonSerializeFile
         Assert.AreEqual("2fd4e1c67a2d28f123849ee1bb76e7391b93eb12",
             json[0]?["checksums"]?[0]?["checksumValue"]?.ToString());
         Assert.AreEqual("Apache-2.0", json[0]?["licenseConcluded"]?.ToString());
-        Assert.AreEqual("Apache-2.0", json[0]?["licenseInfoInFile"]?[0]?.ToString());
+        Assert.AreEqual("Apache-2.0", json[0]?["licenseInfoInFiles"]?[0]?.ToString());
         Assert.AreEqual("This license is used by Jena", json[0]?["licenseComments"]?.ToString());
         Assert.AreEqual("Copyright 2010, 2011 Source Auditor Inc.", json[0]?["copyrightText"]?.ToString());
         Assert.AreEqual("This file is a sample DOAP file", json[0]?["comment"]?.ToString());


### PR DESCRIPTION
This PR fixes serialization type resolving, and also fixes the 'licenseInfoInFiles' name when serializing SPDX files.