### PR TITLE
Fix release to only archive library SBOM.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,12 @@ on:
       version:
         description: 'Release version (1.0.0)'
         required: true
+        type: string
+      publish:
+        description: 'Publish to NuGet'
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   release:
@@ -80,14 +86,25 @@ jobs:
         --no-restore
         --property:PackageVersion=${{ github.event.inputs.version }}
 
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: artifacts-${{ matrix.os }}
+        path: |
+          **/*.nupkg
+          **/manifest.spdx.json
+          **/manifest.spdx.json.sha256
+          *summary.md
+
     - name: Create release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: '**/*.nupkg,**/manifest.spdx.json,**/manifest.spdx.json.sha256,*summary.md'
+        artifacts: 'src/**/*.nupkg,src/**/manifest.spdx.json,src/**/manifest.spdx.json.sha256,*summary.md'
         generateReleaseNotes: true
         tag: ${{ github.event.inputs.version }}
 
     - name: Publish to Nuget
+      if: ${{ github.event.inputs.publish }}
       run: >
         dotnet
         nuget push


### PR DESCRIPTION
This PR fixes archiving releases to only include the NuGet package SBOM. It also adds an option to skip NuGet publish to test the release pipeline.