### PR TITLE
Add ContinuousIntegrationBuild option for CI

### DIFF
--- a/src/DemaConsulting.SpdxModel/DemaConsulting.SpdxModel.csproj
+++ b/src/DemaConsulting.SpdxModel/DemaConsulting.SpdxModel.csproj
@@ -20,6 +20,10 @@
 	<PackageIcon>Icon.png</PackageIcon>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="DemaConsulting.SpdxModel.csproj.DotSettings" />
   </ItemGroup>


### PR DESCRIPTION
This PR implements #29 by adding ContinuousIntegrationBuild when building under Github CI.