### PR TITLE
Drop .NET 6 and update to C# 12

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "dotnet-sonarscanner": {
-      "version": "7.1.1",
+      "version": "8.0.3",
       "commands": [
         "dotnet-sonarscanner"
       ]
     },
     "microsoft.sbom.dotnettool": {
-      "version": "2.2.7",
+      "version": "2.2.8",
       "commands": [
         "sbom-tool"
       ]
     },
     "demaconsulting.spdxtool": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "commands": [
         "spdx-tool"
       ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Checkout 
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Setup dotnet 6/8
       uses: actions/setup-dotnet@v4
@@ -47,6 +49,7 @@ jobs:
         /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
         /d:sonar.host.url="https://sonarcloud.io"
         /d:sonar.cs.opencover.reportsPaths=**/*.opencover.xml
+        /d:sonar.scanner.scanAll=false
 
     - name: Build
       run: >

--- a/src/DemaConsulting.SpdxModel/DemaConsulting.SpdxModel.csproj
+++ b/src/DemaConsulting.SpdxModel/DemaConsulting.SpdxModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/DemaConsulting.SpdxModel/DemaConsulting.SpdxModel.csproj.DotSettings
+++ b/src/DemaConsulting.SpdxModel/DemaConsulting.SpdxModel.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp100</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp120</s:String></wpf:ResourceDictionary>

--- a/src/DemaConsulting.SpdxModel/IO/Spdx2JsonDeserializer.cs
+++ b/src/DemaConsulting.SpdxModel/IO/Spdx2JsonDeserializer.cs
@@ -95,7 +95,7 @@ public static class Spdx2JsonDeserializer
     public static SpdxExternalDocumentReference[] DeserializeExternalDocumentReferences(JsonArray? json)
     {
         return json?.Select(DeserializeExternalDocumentReference).ToArray() ??
-               Array.Empty<SpdxExternalDocumentReference>();
+               [];
     }
 
     /// <summary>
@@ -120,7 +120,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>SPDX Extracted Licensing Infos</returns>
     public static SpdxExtractedLicensingInfo[] DeserializeExtractedLicensingInfos(JsonArray? json)
     {
-        return json?.Select(DeserializeExtractedLicensingInfo).ToArray() ?? Array.Empty<SpdxExtractedLicensingInfo>();
+        return json?.Select(DeserializeExtractedLicensingInfo).ToArray() ?? [];
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>SPDX Files</returns>
     public static SpdxFile[] DeserializeFiles(JsonArray? json)
     {
-        return json?.Select(DeserializeFile).ToArray() ?? Array.Empty<SpdxFile>();
+        return json?.Select(DeserializeFile).ToArray() ?? [];
     }
 
     /// <summary>
@@ -182,7 +182,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>SPDX Packages</returns>
     public static SpdxPackage[] DeserializePackages(JsonArray? json)
     {
-        return json?.Select(DeserializePackage).ToArray() ?? Array.Empty<SpdxPackage>();
+        return json?.Select(DeserializePackage).ToArray() ?? [];
     }
 
     /// <summary>
@@ -232,7 +232,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>SPDX Snippets</returns>
     public static SpdxSnippet[] DeserializeSnippets(JsonArray? json)
     {
-        return json?.Select(DeserializeSnippet).ToArray() ?? Array.Empty<SpdxSnippet>();
+        return json?.Select(DeserializeSnippet).ToArray() ?? [];
     }
 
     /// <summary>
@@ -268,7 +268,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>SPDX Relationships</returns>
     public static SpdxRelationship[] DeserializeRelationships(JsonArray? json)
     {
-        return json?.Select(DeserializeRelationship).ToArray() ?? Array.Empty<SpdxRelationship>();
+        return json?.Select(DeserializeRelationship).ToArray() ?? [];
     }
 
     /// <summary>
@@ -310,7 +310,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>SPDX External References</returns>
     public static SpdxExternalReference[] DeserializeExternalReferences(JsonArray? json)
     {
-        return json?.Select(DeserializeExternalReference).ToArray() ?? Array.Empty<SpdxExternalReference>();
+        return json?.Select(DeserializeExternalReference).ToArray() ?? [];
     }
 
     /// <summary>
@@ -336,7 +336,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>SPDX Checksums</returns>
     public static SpdxChecksum[] DeserializeChecksums(JsonArray? json)
     {
-        return json?.Select(DeserializeChecksum).ToArray() ?? Array.Empty<SpdxChecksum>();
+        return json?.Select(DeserializeChecksum).ToArray() ?? [];
     }
 
     /// <summary>
@@ -360,7 +360,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>SPDX Annotations</returns>
     public static SpdxAnnotation[] DeserializeAnnotations(JsonArray? json)
     {
-        return json?.Select(DeserializeAnnotation).ToArray() ?? Array.Empty<SpdxAnnotation>();
+        return json?.Select(DeserializeAnnotation).ToArray() ?? [];
     }
 
     /// <summary>
@@ -410,7 +410,7 @@ public static class Spdx2JsonDeserializer
     /// <returns>String Array</returns>
     private static string[] ParseStringArray(JsonNode? node, string name)
     {
-        return node?[name]?.AsArray().GetValues<string>().ToArray() ?? Array.Empty<string>();
+        return node?[name]?.AsArray().GetValues<string>().ToArray() ?? [];
     }
 
     /// <summary>

--- a/src/DemaConsulting.SpdxModel/SpdxAnnotation.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxAnnotation.cs
@@ -44,7 +44,7 @@ public sealed class SpdxAnnotation : SpdxElement
     /// This field identifies the person, organization, or tool that has
     /// commented on a file, package, snippet, or the entire document.
     /// </remarks>
-    public string Annotator { get; set; } = string.Empty;
+    public string Annotator { get; set; } = "";
 
     /// <summary>
     /// Annotation Date Field (optional)
@@ -54,7 +54,7 @@ public sealed class SpdxAnnotation : SpdxElement
     /// to the combined date and time in the UTC format, as specified in the
     /// ISO 8601 standard.
     /// </remarks>
-    public string Date { get; set; } = string.Empty;
+    public string Date { get; set; } = "";
 
     /// <summary>
     /// Annotation Type Field (optional)
@@ -64,7 +64,7 @@ public sealed class SpdxAnnotation : SpdxElement
     /// <summary>
     /// Annotation Comment field (optional)
     /// </summary>
-    public string Comment { get; set; } = string.Empty;
+    public string Comment { get; set; } = "";
 
     /// <summary>
     /// Make a deep-copy of this object
@@ -90,20 +90,17 @@ public sealed class SpdxAnnotation : SpdxElement
         EnhanceElement(other);
 
         // Populate the annotator if missing
-        if (string.IsNullOrWhiteSpace(Annotator))
-            Annotator = other.Annotator;
+        Annotator = SpdxHelpers.EnhanceString(Annotator, other.Annotator) ?? "";
 
         // Populate the date if missing
-        if (string.IsNullOrWhiteSpace(Date))
-            Date = other.Date;
+        Date = SpdxHelpers.EnhanceString(Date, other.Date) ?? "";
 
         // Populate the type if missing
         if (Type == SpdxAnnotationType.Missing)
             Type = other.Type;
 
         // Populate the comment if missing
-        if (string.IsNullOrWhiteSpace(Comment))
-            Comment = other.Comment;
+        Comment = SpdxHelpers.EnhanceString(Comment, other.Comment) ?? "";
     }
 
     /// <summary>

--- a/src/DemaConsulting.SpdxModel/SpdxChecksum.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxChecksum.cs
@@ -55,7 +55,7 @@ public sealed class SpdxChecksum
     /// The checksumValue property provides a lower case hexadecimal encoded
     /// digest value produced using a specific algorithm.
     /// </remarks>
-    public string Value { get; set; } = string.Empty;
+    public string Value { get; set; } = "";
 
     /// <summary>
     /// Make a deep-copy of this object
@@ -79,8 +79,7 @@ public sealed class SpdxChecksum
             Algorithm = other.Algorithm;
 
         // Populate the value if missing
-        if (string.IsNullOrWhiteSpace(Value))
-            Value = other.Value;
+        Value = SpdxHelpers.EnhanceString(Value, other.Value) ?? "";
     }
 
     /// <summary>

--- a/src/DemaConsulting.SpdxModel/SpdxCreationInformation.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxCreationInformation.cs
@@ -53,7 +53,7 @@ public sealed class SpdxCreationInformation
     /// involved, use multiple instances of this field. Person name or
     /// organization name may be designated as “anonymous” if appropriate.
     /// </remarks>
-    public string[] Creators { get; set; } = Array.Empty<string>();
+    public string[] Creators { get; set; } = [];
 
     /// <summary>
     /// Created Field
@@ -63,7 +63,7 @@ public sealed class SpdxCreationInformation
     /// be specified according to combined date and time in UTC format as
     /// specified in ISO 8601 standard.
     /// </remarks>
-    public string Created { get; set; } = string.Empty;
+    public string Created { get; set; } = "";
 
     /// <summary>
     /// Creator Comment Field (optional)
@@ -102,16 +102,13 @@ public sealed class SpdxCreationInformation
         Creators = Creators.Concat(other.Creators).Distinct().ToArray();
 
         // Populate the created field if missing
-        if (string.IsNullOrWhiteSpace(Created))
-            Created = other.Created;
+        Created = SpdxHelpers.EnhanceString(Created, other.Created) ?? "";
 
         // Populate the comment field if missing
-        if (string.IsNullOrWhiteSpace(Comment))
-            Comment = other.Comment;
+        Comment = SpdxHelpers.EnhanceString(Comment, other.Comment);
 
         // Populate the license-list-version field if missing
-        if (string.IsNullOrWhiteSpace(LicenseListVersion))
-            LicenseListVersion = other.LicenseListVersion;
+        LicenseListVersion = SpdxHelpers.EnhanceString(LicenseListVersion, other.LicenseListVersion);
     }
 
     /// <summary>

--- a/src/DemaConsulting.SpdxModel/SpdxDocument.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxDocument.cs
@@ -98,23 +98,23 @@ public sealed class SpdxDocument : SpdxElement
     /// document.
     /// </remarks>
     public SpdxExternalDocumentReference[] ExternalDocumentReferences { get; set; } =
-        Array.Empty<SpdxExternalDocumentReference>();
+        [];
 
     /// <summary>
     /// Extracted Licensing Information
     /// </summary>
     public SpdxExtractedLicensingInfo[] ExtractedLicensingInfo { get; set; } =
-        Array.Empty<SpdxExtractedLicensingInfo>();
+        [];
 
     /// <summary>
     /// Annotations
     /// </summary>
-    public SpdxAnnotation[] Annotations { get; set; } = Array.Empty<SpdxAnnotation>();
+    public SpdxAnnotation[] Annotations { get; set; } = [];
 
     /// <summary>
     /// Files
     /// </summary>
-    public SpdxFile[] Files { get; set; } = Array.Empty<SpdxFile>();
+    public SpdxFile[] Files { get; set; } = [];
 
     /// <summary>
     /// Packages
@@ -122,17 +122,17 @@ public sealed class SpdxDocument : SpdxElement
     /// <remarks>
     /// Packages referenced in the SPDX document.
     /// </remarks>
-    public SpdxPackage[] Packages { get; set; } = Array.Empty<SpdxPackage>();
+    public SpdxPackage[] Packages { get; set; } = [];
 
     /// <summary>
     /// Snippets
     /// </summary>
-    public SpdxSnippet[] Snippets { get; set; } = Array.Empty<SpdxSnippet>();
+    public SpdxSnippet[] Snippets { get; set; } = [];
 
     /// <summary>
     /// Relationships
     /// </summary>
-    public SpdxRelationship[] Relationships { get; set; } = Array.Empty<SpdxRelationship>();
+    public SpdxRelationship[] Relationships { get; set; } = [];
 
     /// <summary>
     /// Document Describes field (optional)
@@ -140,7 +140,7 @@ public sealed class SpdxDocument : SpdxElement
     /// <remarks>
     /// Packages, files and/or Snippets described by this SPDX document.
     /// </remarks>
-    public string[] Describes { get; set; } = Array.Empty<string>();
+    public string[] Describes { get; set; } = [];
 
     /// <summary>
     /// Make a deep-copy of this object

--- a/src/DemaConsulting.SpdxModel/SpdxElement.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxElement.cs
@@ -26,13 +26,18 @@ namespace DemaConsulting.SpdxModel;
 public abstract class SpdxElement
 {
     /// <summary>
+    /// No Assertion value
+    /// </summary>
+    public const string NoAssertion = "NOASSERTION";
+
+    /// <summary>
     /// Gets or sets the Element ID
     /// </summary>
     /// <remarks>
     /// Uniquely identify any element in an SPDX document which may be
     /// referenced by other elements.
     /// </remarks>
-    public string Id { get; set; } = string.Empty;
+    public string Id { get; set; } = "";
 
     /// <summary>
     /// Enhance missing fields in the element
@@ -41,7 +46,6 @@ public abstract class SpdxElement
     protected void EnhanceElement(SpdxElement other)
     {
         // Populate the ID if missing
-        if (string.IsNullOrWhiteSpace(Id))
-            Id = other.Id;
+        Id = SpdxHelpers.EnhanceString(Id, other.Id) ?? "";
     }
 }

--- a/src/DemaConsulting.SpdxModel/SpdxExternalDocumentReference.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxExternalDocumentReference.cs
@@ -43,7 +43,7 @@ public sealed class SpdxExternalDocumentReference
     /// <remarks>
     /// A string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.
     /// </remarks>
-    public string ExternalDocumentId { get; set; } = string.Empty;
+    public string ExternalDocumentId { get; set; } = "";
 
     /// <summary>
     /// External Document Checksum Field
@@ -53,7 +53,7 @@ public sealed class SpdxExternalDocumentReference
     /// <summary>
     /// SPDX Document URI Field
     /// </summary>
-    public string Document { get; set; } = string.Empty;
+    public string Document { get; set; } = "";
 
     /// <summary>
     /// Make a deep-copy of this object
@@ -74,14 +74,13 @@ public sealed class SpdxExternalDocumentReference
     public void Enhance(SpdxExternalDocumentReference other)
     {
         // Populate the external document ID if missing
-        if (string.IsNullOrWhiteSpace(ExternalDocumentId))
-            ExternalDocumentId = other.ExternalDocumentId;
+        ExternalDocumentId = SpdxHelpers.EnhanceString(ExternalDocumentId, other.ExternalDocumentId) ?? "";
 
         // Enhance the checksum
         Checksum.Enhance(other.Checksum);
 
-        if (string.IsNullOrWhiteSpace(Document))
-            Document = other.Document;
+        // Enhance the document URI if missing
+        Document = SpdxHelpers.EnhanceString(Document, other.Document) ?? "";
     }
 
     /// <summary>

--- a/src/DemaConsulting.SpdxModel/SpdxExternalReference.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxExternalReference.cs
@@ -54,7 +54,7 @@ public sealed class SpdxExternalReference
     /// Type of the external reference. These are defined in an appendix in
     /// the SPDX specification.
     /// </remarks>
-    public string Type { get; set; } = string.Empty;
+    public string Type { get; set; } = "";
 
     /// <summary>
     /// External Reference Locator Field
@@ -65,7 +65,7 @@ public sealed class SpdxExternalReference
     /// location. The format of the locator is subject to constraints defined
     /// by the type.
     /// </remarks>
-    public string Locator { get; set; } = string.Empty;
+    public string Locator { get; set; } = "";
 
     /// <summary>
     /// External Reference Comment Field (optional)
@@ -96,16 +96,13 @@ public sealed class SpdxExternalReference
             Category = other.Category;
 
         // Populate the type field if missing
-        if (string.IsNullOrWhiteSpace(Type))
-            Type = other.Type;
+        Type = SpdxHelpers.EnhanceString(Type, other.Type) ?? "";
 
         // Populate the locator field if missing
-        if (string.IsNullOrWhiteSpace(Locator))
-            Locator = other.Locator;
+        Locator = SpdxHelpers.EnhanceString(Locator, other.Locator) ?? "";
 
         // Populate the comment if missing
-        if (string.IsNullOrWhiteSpace(Comment))
-            Comment = other.Comment;
+        Comment = SpdxHelpers.EnhanceString(Comment, other.Comment);
     }
 
     /// <summary>

--- a/src/DemaConsulting.SpdxModel/SpdxExtractedLicensingInfo.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxExtractedLicensingInfo.cs
@@ -45,7 +45,7 @@ public sealed class SpdxExtractedLicensingInfo
     /// <remarks>
     /// A human-readable short form license identifier for a license.
     /// </remarks>
-    public string LicenseId { get; set; } = string.Empty;
+    public string LicenseId { get; set; } = "";
 
     /// <summary>
     /// Extracted Text Field
@@ -55,7 +55,7 @@ public sealed class SpdxExtractedLicensingInfo
     /// from the package, file or snippet that is associated with the License
     /// Identifier to aid in future analysis.
     /// </remarks>
-    public string ExtractedText { get; set; } = string.Empty;
+    public string ExtractedText { get; set; } = "";
 
     /// <summary>
     /// License Name Field
@@ -65,7 +65,7 @@ public sealed class SpdxExtractedLicensingInfo
     /// <summary>
     /// License Cross-Reference Field (optional)
     /// </summary>
-    public string[] CrossReferences { get; set; } = Array.Empty<string>();
+    public string[] CrossReferences { get; set; } = [];
 
     /// <summary>
     /// License Comment Field (optional)
@@ -93,23 +93,19 @@ public sealed class SpdxExtractedLicensingInfo
     public void Enhance(SpdxExtractedLicensingInfo other)
     {
         // Populate the license-id field if missing
-        if (string.IsNullOrWhiteSpace(LicenseId))
-            LicenseId = other.LicenseId;
+        LicenseId = SpdxHelpers.EnhanceString(LicenseId, other.LicenseId) ?? "";
 
         // Populate the extracted-text field if missing
-        if (string.IsNullOrWhiteSpace(ExtractedText))
-            ExtractedText = other.ExtractedText;
+        ExtractedText = SpdxHelpers.EnhanceString(ExtractedText, other.ExtractedText) ?? "";
 
         // Populate the name field if missing
-        if (string.IsNullOrWhiteSpace(Name))
-            Name = other.Name;
+        Name = SpdxHelpers.EnhanceString(Name, other.Name);
 
         // Merge the cross-references
         CrossReferences = CrossReferences.Concat(other.CrossReferences).Distinct().ToArray();
 
         // Populate the comment field if missing
-        if (string.IsNullOrWhiteSpace(Comment))
-            Comment = other.Comment;
+        Comment = SpdxHelpers.EnhanceString(Comment, other.Comment);
     }
 
     /// <summary>

--- a/src/DemaConsulting.SpdxModel/SpdxFile.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxFile.cs
@@ -40,7 +40,7 @@ public sealed class SpdxFile : SpdxLicenseElement
     /// <remarks>
     /// The name of the file relative to the root of the package.
     /// </remarks>
-    public string FileName { get; set; } = string.Empty;
+    public string FileName { get; set; } = "";
 
     /// <summary>
     /// File Types Field
@@ -48,7 +48,7 @@ public sealed class SpdxFile : SpdxLicenseElement
     /// <remarks>
     /// The type of the file.
     /// </remarks>
-    public SpdxFileType[] FileTypes { get; set; } = Array.Empty<SpdxFileType>();
+    public SpdxFileType[] FileTypes { get; set; } = [];
 
     /// <summary>
     /// File Checksums
@@ -57,7 +57,7 @@ public sealed class SpdxFile : SpdxLicenseElement
     /// The checksum property provides a mechanism that can be used to verify
     /// that the contents of a file have not changed.
     /// </remarks>
-    public SpdxChecksum[] Checksums { get; set; } = Array.Empty<SpdxChecksum>();
+    public SpdxChecksum[] Checksums { get; set; } = [];
 
     /// <summary>
     /// License Information In File Field
@@ -70,7 +70,7 @@ public sealed class SpdxFile : SpdxLicenseElement
     ///
     /// If not present for a file, it implies an equivalent meaning to NOASSERTION.
     /// </remarks>
-    public string[] LicenseInfoInFiles { get; set; } = Array.Empty<string>();
+    public string[] LicenseInfoInFiles { get; set; } = [];
 
     /// <summary>
     /// File Comment Field (optional)
@@ -96,7 +96,7 @@ public sealed class SpdxFile : SpdxLicenseElement
     /// and/or authors who may not be copyright holders yet contributed to the
     /// file content.
     /// </remarks>
-    public string[] Contributors { get; set; } = Array.Empty<string>();
+    public string[] Contributors { get; set; } = [];
 
     /// <summary>
     /// Make a deep-copy of this object
@@ -130,8 +130,7 @@ public sealed class SpdxFile : SpdxLicenseElement
         EnhanceLicenseElement(other);
 
         // Populate the file name if missing
-        if (string.IsNullOrWhiteSpace(FileName))
-            FileName = other.FileName;
+        FileName = SpdxHelpers.EnhanceString(FileName, other.FileName) ?? "";
 
         // Merge the file types
         FileTypes = FileTypes.Concat(other.FileTypes).Distinct().ToArray();
@@ -143,12 +142,10 @@ public sealed class SpdxFile : SpdxLicenseElement
         LicenseInfoInFiles = LicenseInfoInFiles.Concat(other.LicenseInfoInFiles).Distinct().ToArray();
 
         // Populate the comment if missing
-        if (string.IsNullOrWhiteSpace(Comment))
-            Comment = other.Comment;
+        Comment = SpdxHelpers.EnhanceString(Comment, other.Comment);
 
         // Populate the notice if missing
-        if (string.IsNullOrWhiteSpace(Notice))
-            Notice = other.Notice;
+        Notice = SpdxHelpers.EnhanceString(Notice, other.Notice);
 
         // Merge the contributors
         Contributors = Contributors.Concat(other.Contributors).Distinct().ToArray();

--- a/src/DemaConsulting.SpdxModel/SpdxHelpers.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxHelpers.cs
@@ -41,4 +41,40 @@ internal static class SpdxHelpers
     {
         return string.IsNullOrEmpty(value) || DateTimeRegex.IsMatch(value);
     }
+
+    /// <summary>
+    /// This method picks the best string.
+    /// </summary>
+    /// <param name="values">String values to pick from</param>
+    /// <returns>Best string</returns>
+    internal static string? EnhanceString(params string?[] values)
+    {
+        // Start assuming no string
+        string? ret = null;
+        var retFitness = 0;
+
+        // Select the string with the highest fitness
+        foreach (var value in values)
+        {
+            // Calculate the fitness
+            var fitness = value switch
+            {
+                null => 0,
+                "" => 1,
+                SpdxElement.NoAssertion => 2,
+                _ => 3
+            };
+
+            // Skip if not an improvement
+            if (fitness <= retFitness)
+                continue;
+
+            // Update the return value
+            ret = value;
+            retFitness = fitness;
+        }
+
+        // Return the fittest string
+        return ret;
+    }
 }

--- a/src/DemaConsulting.SpdxModel/SpdxLicenseElement.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxLicenseElement.cs
@@ -36,7 +36,7 @@ public abstract class SpdxLicenseElement : SpdxElement
     ///
     /// If not present, it implies an equivalent meaning to NOASSERTION.
     /// </remarks>
-    public string ConcludedLicense { get; set; } = string.Empty;
+    public string ConcludedLicense { get; set; } = "";
 
     /// <summary>
     /// Comments On License Field (optional)
@@ -55,7 +55,7 @@ public abstract class SpdxLicenseElement : SpdxElement
     ///
     /// If not present, it implies an equivalent meaning to NOASSERTION.
     /// </remarks>
-    public string CopyrightText { get; set; } = string.Empty;
+    public string CopyrightText { get; set; } = "";
 
     /// <summary>
     /// Attribution Text Field
@@ -65,7 +65,7 @@ public abstract class SpdxLicenseElement : SpdxElement
     /// acknowledgements that may be required to be communicated in some
     /// contexts.
     /// </remarks>
-    public string[] AttributionText { get; set; } = Array.Empty<string>();
+    public string[] AttributionText { get; set; } = [];
 
     /// <summary>
     /// Annotations
@@ -73,7 +73,7 @@ public abstract class SpdxLicenseElement : SpdxElement
     /// <remarks>
     /// Provide additional information about this element.
     /// </remarks>
-    public SpdxAnnotation[] Annotations { get; set; } = Array.Empty<SpdxAnnotation>();
+    public SpdxAnnotation[] Annotations { get; set; } = [];
 
     /// <summary>
     /// Enhance missing fields in the license element
@@ -85,16 +85,13 @@ public abstract class SpdxLicenseElement : SpdxElement
         EnhanceElement(other);
 
         // Populate the concluded license if missing
-        if (string.IsNullOrWhiteSpace(ConcludedLicense) || ConcludedLicense == "NOASSERTION")
-            ConcludedLicense = other.ConcludedLicense;
+        ConcludedLicense = SpdxHelpers.EnhanceString(ConcludedLicense, other.ConcludedLicense) ?? "";
 
         // Populate the license comments if missing
-        if (string.IsNullOrWhiteSpace(LicenseComments))
-            LicenseComments = other.LicenseComments;
+        LicenseComments = SpdxHelpers.EnhanceString(LicenseComments, other.LicenseComments);
 
         // Populate the copyright text if missing
-        if (string.IsNullOrWhiteSpace(CopyrightText) || CopyrightText == "NOASSERTION")
-            CopyrightText = other.CopyrightText;
+        CopyrightText = SpdxHelpers.EnhanceString(CopyrightText, other.CopyrightText) ?? "";
 
         // Merge the attribution texts
         AttributionText = AttributionText.Concat(other.AttributionText).Distinct().ToArray();

--- a/src/DemaConsulting.SpdxModel/SpdxPackage.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxPackage.cs
@@ -40,7 +40,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
     /// <remarks>
     /// Name of this package.
     /// </remarks>
-    public string Name { get; set; } = string.Empty;
+    public string Name { get; set; } = "";
 
     /// <summary>
     /// Package Version Field (optional)
@@ -96,7 +96,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
     /// package is not downloadable or that no attempt was made to determine
     /// its download location, respectively.
     /// </remarks>
-    public string DownloadLocation { get; set; } = string.Empty;
+    public string DownloadLocation { get; set; } = "";
 
     /// <summary>
     /// Files Analyzed Field (optional)
@@ -117,7 +117,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
     /// SPDX ID for files. Indicates that a particular file belongs to this
     /// package.
     /// </remarks>
-    public string[] HasFiles { get; set; } = Array.Empty<string>();
+    public string[] HasFiles { get; set; } = [];
 
     /// <summary>
     /// Package Verification Code (optional)
@@ -130,7 +130,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
     /// <summary>
     /// Package Checksum Field (optional)
     /// </summary>
-    public SpdxChecksum[] Checksums { get; set; } = Array.Empty<SpdxChecksum>();
+    public SpdxChecksum[] Checksums { get; set; } = [];
 
     /// <summary>
     /// Package Home Page Field (optional)
@@ -157,7 +157,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
     /// If not present and FilesAnalyzed property is true or omitted, it implies
     /// an equivalent meaning to NOASSERTION.
     /// </remarks>
-    public string[] LicenseInfoFromFiles { get; set; } = Array.Empty<string>();
+    public string[] LicenseInfoFromFiles { get; set; } = [];
 
     /// <summary>
     /// Declared License Field
@@ -169,7 +169,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
     /// packager, have declared. Declarations by the original software creator
     /// should be preferred, if they exist.
     /// </remarks>
-    public string DeclaredLicense { get; set; } = string.Empty;
+    public string DeclaredLicense { get; set; } = "";
 
     /// <summary>
     /// Package Summary Description Field (optional)
@@ -200,7 +200,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
     /// of additional information, metadata, enumerations, asset identifiers,
     /// or downloadable content believed to be relevant to the Package.
     /// </remarks>
-    public SpdxExternalReference[] ExternalReferences { get; set; } = Array.Empty<SpdxExternalReference>();
+    public SpdxExternalReference[] ExternalReferences { get; set; } = [];
 
     /// <summary>
     /// Primary Package Purpose Field (optional)
@@ -254,13 +254,13 @@ public sealed class SpdxPackage : SpdxLicenseElement
             Originator = Originator,
             DownloadLocation = DownloadLocation,
             FilesAnalyzed = FilesAnalyzed,
-            HasFiles = HasFiles.ToArray(),
+            HasFiles = [..HasFiles],
             VerificationCode = VerificationCode?.DeepCopy(),
             Checksums = Checksums.Select(c => c.DeepCopy()).ToArray(),
             HomePage = HomePage,
             SourceInformation = SourceInformation,
             ConcludedLicense = ConcludedLicense,
-            LicenseInfoFromFiles = LicenseInfoFromFiles.ToArray(),
+            LicenseInfoFromFiles = [..LicenseInfoFromFiles],
             DeclaredLicense = DeclaredLicense,
             LicenseComments = LicenseComments,
             CopyrightText = CopyrightText,
@@ -268,7 +268,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
             Description = Description,
             Comment = Comment,
             ExternalReferences = ExternalReferences.Select(r => r.DeepCopy()).ToArray(),
-            AttributionText = AttributionText.ToArray(),
+            AttributionText = [..AttributionText],
             PrimaryPackagePurpose = PrimaryPackagePurpose,
             ReleaseDate = ReleaseDate,
             BuiltDate = BuiltDate,
@@ -286,32 +286,26 @@ public sealed class SpdxPackage : SpdxLicenseElement
         EnhanceLicenseElement(other);
 
         // Populate the name field if missing
-        if (string.IsNullOrWhiteSpace(Name))
-            Name = other.Name;
+        Name = SpdxHelpers.EnhanceString(Name, other.Name) ?? "";
 
         // Populate the version field if missing
-        if (string.IsNullOrWhiteSpace(Version))
-            Version = other.Version;
+        Version = SpdxHelpers.EnhanceString(Version, other.Version);
 
         // Populate the file-name field if missing
-        if (string.IsNullOrWhiteSpace(FileName))
-            FileName = other.FileName;
+        FileName = SpdxHelpers.EnhanceString(FileName, other.FileName);
 
         // Populate the supplier field if missing
-        if (string.IsNullOrWhiteSpace(Supplier) || Supplier == "NOASSERTION")
-            Supplier = other.Supplier;
+        Supplier = SpdxHelpers.EnhanceString(Supplier, other.Supplier);
 
         // Populate the originator field if missing
-        if (string.IsNullOrWhiteSpace(Originator) || Originator == "NOASSERTION")
-            Originator = other.Originator;
+        Originator = SpdxHelpers.EnhanceString(Originator, other.Originator);
 
         // Populate the download-location field if missing
-        if (string.IsNullOrWhiteSpace(DownloadLocation) || DownloadLocation == "NOASSERTION")
-            DownloadLocation = other.DownloadLocation;
+        DownloadLocation = SpdxHelpers.EnhanceString(DownloadLocation, other.DownloadLocation) ?? "";
 
         // Enhance or populate the verification code
         if (VerificationCode != null && other.VerificationCode != null)
-            VerificationCode?.Enhance(other.VerificationCode);
+            VerificationCode.Enhance(other.VerificationCode);
         else
             VerificationCode = other.VerificationCode?.DeepCopy();
 
@@ -319,50 +313,40 @@ public sealed class SpdxPackage : SpdxLicenseElement
         Checksums = SpdxChecksum.Enhance(Checksums, other.Checksums);
 
         // Populate the home-page if missing
-        if (string.IsNullOrWhiteSpace(HomePage) || HomePage == "NOASSERTION")
-            HomePage = other.HomePage;
+        HomePage = SpdxHelpers.EnhanceString(HomePage, other.HomePage);
 
         // Populate the source-information if missing
-        if (string.IsNullOrWhiteSpace(SourceInformation))
-            SourceInformation = other.SourceInformation;
+        SourceInformation = SpdxHelpers.EnhanceString(SourceInformation, other.SourceInformation);
 
         // Merge the license-info-from-files entries
         LicenseInfoFromFiles = LicenseInfoFromFiles.Concat(other.LicenseInfoFromFiles).Distinct().ToArray();
 
         // Populate the declared-license field if missing
-        if (string.IsNullOrWhiteSpace(DeclaredLicense) || DeclaredLicense == "NOASSERTION")
-            DeclaredLicense = other.DeclaredLicense;
+        DeclaredLicense = SpdxHelpers.EnhanceString(DeclaredLicense, other.DeclaredLicense) ?? "";
 
         // Populate the summary field if missing
-        if (string.IsNullOrWhiteSpace(Summary))
-            Summary = other.Summary;
+        Summary = SpdxHelpers.EnhanceString(Summary, other.Summary);
 
         // Populate the description field if missing
-        if (string.IsNullOrWhiteSpace(Description))
-            Description = other.Description;
+        Description = SpdxHelpers.EnhanceString(Description, other.Description);
 
         // Populate the comment field if missing
-        if (string.IsNullOrWhiteSpace(Comment))
-            Comment = other.Comment;
+        Comment = SpdxHelpers.EnhanceString(Comment, other.Comment);
 
         // Enhance external references
         ExternalReferences = SpdxExternalReference.Enhance(ExternalReferences, other.ExternalReferences);
 
         // Populate the primary-package-purpose field if missing
-        if (string.IsNullOrWhiteSpace(PrimaryPackagePurpose))
-            PrimaryPackagePurpose = other.PrimaryPackagePurpose;
+        PrimaryPackagePurpose = SpdxHelpers.EnhanceString(PrimaryPackagePurpose, other.PrimaryPackagePurpose);
 
         // Populate the release-date field if missing
-        if (string.IsNullOrWhiteSpace(ReleaseDate))
-            ReleaseDate = other.ReleaseDate;
+        ReleaseDate = SpdxHelpers.EnhanceString(ReleaseDate, other.ReleaseDate);
 
         // Populate the built-date field if missing
-        if (string.IsNullOrWhiteSpace(BuiltDate))
-            BuiltDate = other.BuiltDate;
+        BuiltDate = SpdxHelpers.EnhanceString(BuiltDate, other.BuiltDate);
 
         // Populate the valid-until-date field if missing
-        if (string.IsNullOrWhiteSpace(ValidUntilDate))
-            ValidUntilDate = other.ValidUntilDate;
+        ValidUntilDate = SpdxHelpers.EnhanceString(ValidUntilDate, other.ValidUntilDate);
     }
 
     /// <summary>
@@ -394,7 +378,7 @@ public sealed class SpdxPackage : SpdxLicenseElement
         }
 
         // Return as array
-        return list.ToArray();
+        return [..list];
     }
 
     /// <summary>
@@ -415,14 +399,14 @@ public sealed class SpdxPackage : SpdxLicenseElement
 
         // Validate Package Supplier Field
         if (Supplier != null && 
-            Supplier != "NOASSERTION" && 
+            Supplier != NoAssertion && 
             !Supplier.StartsWith("Person:") &&
             !Supplier.StartsWith("Organization:"))
             issues.Add($"Package {Name} Invalid Package Supplier Field");
 
         // Validate Package Originator Field
         if (Originator != null &&
-            Originator != "NOASSERTION" &&
+            Originator != NoAssertion &&
             !Originator.StartsWith("Person:") &&
             !Originator.StartsWith("Organization:"))
             issues.Add($"Package {Name} Invalid Package Originator Field");

--- a/src/DemaConsulting.SpdxModel/SpdxPackageVerificationCode.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxPackageVerificationCode.cs
@@ -52,7 +52,7 @@ public sealed class SpdxPackageVerificationCode
     /// would be impossible to correctly calculate the verification codes in
     /// both files.
     /// </remarks>
-    public string[] ExcludedFiles { get; set; } = Array.Empty<string>();
+    public string[] ExcludedFiles { get; set; } = [];
 
     /// <summary>
     /// Verification Code Value Field
@@ -60,7 +60,7 @@ public sealed class SpdxPackageVerificationCode
     /// <remarks>
     /// The actual package verification code as a hex encoded value.
     /// </remarks>
-    public string Value { get; set; } = string.Empty;
+    public string Value { get; set; } = "";
 
     /// <summary>
     /// Make a deep-copy of this object
@@ -83,8 +83,7 @@ public sealed class SpdxPackageVerificationCode
         ExcludedFiles = ExcludedFiles.Concat(other.ExcludedFiles).Distinct().ToArray();
 
         // Populate the value field if missing
-        if (string.IsNullOrWhiteSpace(Value))
-            Value = other.Value;
+        Value = SpdxHelpers.EnhanceString(Value, other.Value) ?? "";
     }
 
     /// <summary>

--- a/src/DemaConsulting.SpdxModel/SpdxRelationship.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxRelationship.cs
@@ -54,7 +54,7 @@ public sealed class SpdxRelationship : SpdxElement
     /// <remarks>
     /// SPDX ID for SpdxElement.  A related SpdxElement.
     /// </remarks>
-    public string RelatedSpdxElement { get; set; } = string.Empty;
+    public string RelatedSpdxElement { get; set; } = "";
 
     /// <summary>
     /// Relationship Type Field
@@ -92,16 +92,14 @@ public sealed class SpdxRelationship : SpdxElement
         EnhanceElement(other);
         
         // Populate the related-element field if missing
-        if (string.IsNullOrWhiteSpace(RelatedSpdxElement))
-            RelatedSpdxElement = other.RelatedSpdxElement;
+        RelatedSpdxElement = SpdxHelpers.EnhanceString(RelatedSpdxElement, other.RelatedSpdxElement) ?? "";
 
         // Populate the relationship-type field if missing
         if (RelationshipType == SpdxRelationshipType.Missing)
             RelationshipType = other.RelationshipType;
 
         // Populate the comment if missing
-        if (string.IsNullOrWhiteSpace(Comment))
-            Comment = other.Comment;
+        Comment = SpdxHelpers.EnhanceString(Comment, other.Comment) ?? "";
     }
 
     /// <summary>
@@ -133,7 +131,7 @@ public sealed class SpdxRelationship : SpdxElement
         }
 
         // Return as array
-        return list.ToArray();
+        return [..list];
     }
 
     /// <summary>
@@ -152,7 +150,7 @@ public sealed class SpdxRelationship : SpdxElement
         // Validate Related SPDX Element Field - can be NOASSERTION or external reference
         if (RelatedSpdxElement.Length == 0)
             issues.Add("Relationship Invalid Related SPDX Element Field");
-        else if (!RelatedSpdxElement.StartsWith("DocumentRef-") && RelatedSpdxElement != "NOASSERTION" && doc != null && doc.GetElement(RelatedSpdxElement) == null)
+        else if (!RelatedSpdxElement.StartsWith("DocumentRef-") && RelatedSpdxElement != NoAssertion && doc != null && doc.GetElement(RelatedSpdxElement) == null)
             issues.Add($"Relationship Invalid Related SPDX Element Field: {RelatedSpdxElement}");
 
         // Validate Relationship Type Field

--- a/src/DemaConsulting.SpdxModel/SpdxSnippet.cs
+++ b/src/DemaConsulting.SpdxModel/SpdxSnippet.cs
@@ -44,7 +44,7 @@ public sealed class SpdxSnippet : SpdxLicenseElement
     /// <remarks>
     /// SPDX ID for File. File containing the SPDX element (e.g. the file containing the snippet).
     /// </remarks>
-    public string SnippetFromFile { get; set; } = string.Empty;
+    public string SnippetFromFile { get; set; } = "";
 
     /// <summary>
     /// Snippet Byte Range Start Field
@@ -77,7 +77,7 @@ public sealed class SpdxSnippet : SpdxLicenseElement
     ///
     /// If not present, it implies an equivalent meaning to NOASSERTION.
     /// </remarks>
-    public string[] LicenseInfoInSnippet { get; set; } = Array.Empty<string>();
+    public string[] LicenseInfoInSnippet { get; set; } = [];
 
     /// <summary>
     /// Snippet Comment Field (optional)
@@ -125,8 +125,7 @@ public sealed class SpdxSnippet : SpdxLicenseElement
         EnhanceLicenseElement(other);
 
         // Populate the snippet-from-file field if missing
-        if (string.IsNullOrWhiteSpace(SnippetFromFile))
-            SnippetFromFile = other.SnippetFromFile;
+        SnippetFromFile = SpdxHelpers.EnhanceString(SnippetFromFile, other.SnippetFromFile) ?? "";
 
         // Populate the snippet-byte-start field if missing
         if (SnippetByteStart <= 0)
@@ -148,12 +147,10 @@ public sealed class SpdxSnippet : SpdxLicenseElement
         LicenseInfoInSnippet = LicenseInfoInSnippet.Concat(other.LicenseInfoInSnippet).Distinct().ToArray();
 
         // Populate the comment field if missing
-        if (string.IsNullOrWhiteSpace(Comment))
-            Comment = other.Comment;
+        Comment = SpdxHelpers.EnhanceString(Comment, other.Comment);
 
         // Populate the name field if missing
-        if (string.IsNullOrWhiteSpace(Name))
-            Name = other.Name;
+        Name = SpdxHelpers.EnhanceString(Name, other.Name);
     }
 
     /// <summary>

--- a/test/DemaConsulting.SpdxModel.Tests/DemaConsulting.SpdxModel.Tests.csproj
+++ b/test/DemaConsulting.SpdxModel.Tests/DemaConsulting.SpdxModel.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 

--- a/test/DemaConsulting.SpdxModel.Tests/DemaConsulting.SpdxModel.Tests.csproj.DotSettings
+++ b/test/DemaConsulting.SpdxModel.Tests/DemaConsulting.SpdxModel.Tests.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp100</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp120</s:String></wpf:ResourceDictionary>

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeCreationInformation.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeCreationInformation.cs
@@ -34,12 +34,12 @@ public class Spdx2JsonSerializeCreationInformation
             Comment =
                 "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
             Created = "2010-01-29T18:30:22Z",
-            Creators = new[]
-            {
+            Creators =
+            [
                 "Tool: LicenseFind-1.0",
                 "Organization: ExampleCodeInspect ()",
                 "Person: Jane Doe ()"
-            },
+            ],
             LicenseListVersion = "3.17"
         };
 

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeDocument.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeDocument.cs
@@ -38,30 +38,30 @@ public class Spdx2JsonSerializeDocument
                 Comment =
                     "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
                 Created = "2010-01-29T18:30:22Z",
-                Creators = new[]
-                {
+                Creators =
+                [
                     "Tool: LicenseFind-1.0",
                     "Organization: ExampleCodeInspect ()",
                     "Person: Jane Doe ()"
-                },
+                ],
                 LicenseListVersion = "3.17"
             },
             Name = "SPDX-Tools-v2.0",
             DataLicense = "CC0-1.0",
             Comment = "This document was created using SPDX 2.0 using licenses from the web site.",
-            ExternalDocumentReferences = Array.Empty<SpdxExternalDocumentReference>(),
-            ExtractedLicensingInfo = Array.Empty<SpdxExtractedLicensingInfo>(),
-            Describes = new[]
-            {
+            ExternalDocumentReferences = [],
+            ExtractedLicensingInfo = [],
+            Describes =
+            [
                 "SPDXRef-File",
                 "SPDXRef-File",
                 "SPDXRef-Package"
-            },
+            ],
             DocumentNamespace = "http://spdx.org/spdxdocs/spdx-example-json-2.3-444504E0-4F89-41D3-9A0C-0305E82C3301",
-            Packages = Array.Empty<SpdxPackage>(),
-            Files = Array.Empty<SpdxFile>(),
-            Snippets = Array.Empty<SpdxSnippet>(),
-            Relationships = Array.Empty<SpdxRelationship>()
+            Packages = [],
+            Files = [],
+            Snippets = [],
+            Relationships = []
         };
 
         // Act

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeExtractedLicensingInfo.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeExtractedLicensingInfo.cs
@@ -34,7 +34,7 @@ public class Spdx2JsonSerializeExtractedLicensingInfo
             LicenseId = "MIT",
             ExtractedText = "This is the MIT license",
             Name = "MIT License",
-            CrossReferences = new[] { "https://opensource.org/licenses/MIT" },
+            CrossReferences = ["https://opensource.org/licenses/MIT"],
             Comment = "This is a comment"
         };
 
@@ -60,7 +60,7 @@ public class Spdx2JsonSerializeExtractedLicensingInfo
                 LicenseId = "MIT",
                 ExtractedText = "This is the MIT license",
                 Name = "MIT License",
-                CrossReferences = new[] { "https://opensource.org/licenses/MIT" },
+                CrossReferences = ["https://opensource.org/licenses/MIT"],
                 Comment = "This is a comment"
             }
         };

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeFile.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeFile.cs
@@ -33,35 +33,35 @@ public class Spdx2JsonSerializeFile
         {
             Id = "SPDXRef-DoapSource",
             FileName = "./src/org/spdx/parser/DOAPProject.java",
-            FileTypes = new[] { SpdxFileType.Source },
-            Checksums = new[]
-            {
+            FileTypes = [SpdxFileType.Source],
+            Checksums =
+            [
                 new SpdxChecksum
                 {
                     Algorithm = SpdxChecksumAlgorithm.Sha1,
                     Value = "2fd4e1c67a2d28f123849ee1bb76e7391b93eb12"
                 }
-            },
+            ],
             ConcludedLicense = "Apache-2.0",
-            LicenseInfoInFiles = new[] { "Apache-2.0" },
+            LicenseInfoInFiles = ["Apache-2.0"],
             LicenseComments = "This license is used by Jena",
             CopyrightText = "Copyright 2010, 2011 Source Auditor Inc.",
             Comment = "This file is a sample DOAP file",
             Notice = "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com",
-            Contributors = new[]
-            {
+            Contributors =
+            [
                 "Protecode Inc.",
                 "SPDX Technical Team Members",
                 "Open Logic Inc.",
                 "Source Auditor Inc.",
                 "Black Duck Software In.c"
-            },
-            AttributionText = new[]
-            {
+            ],
+            AttributionText =
+            [
                 "All advertising materials mentioning features or use of this software must display the following acknowledgement: This product includes software developed by the AT&T."
-            },
-            Annotations = new[]
-            {
+            ],
+            Annotations =
+            [
                 new SpdxAnnotation
                 {
                     Date = "2011-01-29T18:30:22Z",
@@ -69,7 +69,7 @@ public class Spdx2JsonSerializeFile
                     Comment = "Person: File Commenter",
                     Annotator = "File level annotation"
                 }
-            }
+            ]
         };
 
         // Act
@@ -112,35 +112,35 @@ public class Spdx2JsonSerializeFile
             {
                 Id = "SPDXRef-DoapSource",
                 FileName = "./src/org/spdx/parser/DOAPProject.java",
-                FileTypes = new[] { SpdxFileType.Source },
-                Checksums = new[]
-                {
+                FileTypes = [SpdxFileType.Source],
+                Checksums =
+                [
                     new SpdxChecksum
                     {
                         Algorithm = SpdxChecksumAlgorithm.Sha1,
                         Value = "2fd4e1c67a2d28f123849ee1bb76e7391b93eb12"
                     }
-                },
+                ],
                 ConcludedLicense = "Apache-2.0",
-                LicenseInfoInFiles = new[] { "Apache-2.0" },
+                LicenseInfoInFiles = ["Apache-2.0"],
                 LicenseComments = "This license is used by Jena",
                 CopyrightText = "Copyright 2010, 2011 Source Auditor Inc.",
                 Comment = "This file is a sample DOAP file",
                 Notice = "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com",
-                Contributors = new[]
-                {
+                Contributors =
+                [
                     "Protecode Inc.",
                     "SPDX Technical Team Members",
                     "Open Logic Inc.",
                     "Source Auditor Inc.",
                     "Black Duck Software In.c"
-                },
-                AttributionText = new[]
-                {
+                ],
+                AttributionText =
+                [
                     "All advertising materials mentioning features or use of this software must display the following acknowledgement: This product includes software developed by the AT&T."
-                },
-                Annotations = new[]
-                {
+                ],
+                Annotations =
+                [
                     new SpdxAnnotation
                     {
                         Date = "2011-01-29T18:30:22Z",
@@ -148,7 +148,7 @@ public class Spdx2JsonSerializeFile
                         Comment = "Person: File Commenter",
                         Annotator = "File level annotation"
                     }
-                }
+                ]
             }
         };
 

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializePackage.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializePackage.cs
@@ -37,8 +37,8 @@ public class Spdx2JsonSerializePackage
             FileName = "glibc-2.11.1.tar.gz",
             Supplier = "Person: Jane Doe (jane.doe@example.com)",
             Originator = "Organization: ExampleCodeInspect (contact@example.com)",
-            Annotations = new[]
-            {
+            Annotations =
+            [
                 new SpdxAnnotation
                 {
                     Date = "2011-01-29T18:30:22Z",
@@ -46,14 +46,14 @@ public class Spdx2JsonSerializePackage
                     Annotator = "Person: Package Commenter",
                     Comment = "Package level annotation"
                 }
-            },
-            AttributionText = new[]
-            {
+            ],
+            AttributionText =
+            [
                 "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually."
-            },
+            ],
             BuiltDate = "2011-01-29T18:30:22Z",
-            Checksums = new[]
-            {
+            Checksums =
+            [
                 new SpdxChecksum
                 {
                     Algorithm = SpdxChecksumAlgorithm.Sha1,
@@ -64,25 +64,25 @@ public class Spdx2JsonSerializePackage
                     Algorithm = SpdxChecksumAlgorithm.Sha256,
                     Value = "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
                 }
-            },
+            ],
             CopyrightText = "Copyright 2008-2010 John Smith",
             Description =
                 "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
             DownloadLocation = "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
-            ExternalReferences = new[]
-            {
+            ExternalReferences =
+            [
                 new SpdxExternalReference
                 {
                     Category = SpdxReferenceCategory.Security,
                     Locator = "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
                     Type = "cpe23Type"
                 }
-            },
+            ],
             FilesAnalyzed = true,
-            HasFiles = new[] { "file1.txt", "file2.txt" },
+            HasFiles = ["file1.txt", "file2.txt"],
             VerificationCode = new SpdxPackageVerificationCode
             {
-                ExcludedFiles = new[] { "file1.txt" },
+                ExcludedFiles = ["file1.txt"],
                 Value = "1234567890abcdef"
             }
         };
@@ -141,8 +141,8 @@ public class Spdx2JsonSerializePackage
                 FileName = "glibc-2.11.1.tar.gz",
                 Supplier = "Person: Jane Doe (jane.doe@example.com)",
                 Originator = "Organization: ExampleCodeInspect (contact@example.com)",
-                Annotations = new[]
-                {
+                Annotations =
+                [
                     new SpdxAnnotation
                     {
                         Date = "2011-01-29T18:30:22Z",
@@ -150,14 +150,14 @@ public class Spdx2JsonSerializePackage
                         Annotator = "Person: Package Commenter",
                         Comment = "Package level annotation"
                     }
-                },
-                AttributionText = new[]
-                {
+                ],
+                AttributionText =
+                [
                     "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually."
-                },
+                ],
                 BuiltDate = "2011-01-29T18:30:22Z",
-                Checksums = new[]
-                {
+                Checksums =
+                [
                     new SpdxChecksum
                     {
                         Algorithm = SpdxChecksumAlgorithm.Sha1,
@@ -168,25 +168,25 @@ public class Spdx2JsonSerializePackage
                         Algorithm = SpdxChecksumAlgorithm.Sha256,
                         Value = "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
                     }
-                },
+                ],
                 CopyrightText = "Copyright 2008-2010 John Smith",
                 Description =
                     "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
                 DownloadLocation = "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
-                ExternalReferences = new[]
-                {
+                ExternalReferences =
+                [
                     new SpdxExternalReference
                     {
                         Category = SpdxReferenceCategory.Security,
                         Locator = "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
                         Type = "cpe23Type"
                     }
-                },
+                ],
                 FilesAnalyzed = true,
-                HasFiles = new[] { "file1.txt", "file2.txt" },
+                HasFiles = ["file1.txt", "file2.txt"],
                 VerificationCode = new SpdxPackageVerificationCode
                 {
-                    ExcludedFiles = new[] { "file1.txt" },
+                    ExcludedFiles = ["file1.txt"],
                     Value = "1234567890abcdef"
                 }
             }

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializePackageVerificationCode.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializePackageVerificationCode.cs
@@ -32,11 +32,11 @@ public class Spdx2JsonSerializePackageVerificationCode
         var code = new SpdxPackageVerificationCode
         {
             Value = "d3b07384d113edec49eaa6238ad5ff00",
-            ExcludedFiles = new[]
-            {
+            ExcludedFiles =
+            [
                 "file1.txt",
                 "file2.txt"
-            }
+            ]
         };
 
         // Act

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeSnippet.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonSerializeSnippet.cs
@@ -38,12 +38,12 @@ public class Spdx2JsonSerializeSnippet
             SnippetLineStart = 3,
             SnippetLineEnd = 4,
             ConcludedLicense = "ConcludedLicense",
-            LicenseInfoInSnippet = new[] { "LicenseInfoInSnippet" },
+            LicenseInfoInSnippet = ["LicenseInfoInSnippet"],
             LicenseComments = "LicenseComments",
             CopyrightText = "Copyright",
             Comment = "Comment",
             Name = "Name",
-            AttributionText = new[] { "AttributionText" }
+            AttributionText = ["AttributionText"]
         };
 
         // Act
@@ -85,12 +85,12 @@ public class Spdx2JsonSerializeSnippet
                 SnippetLineStart = 3,
                 SnippetLineEnd = 4,
                 ConcludedLicense = "ConcludedLicense",
-                LicenseInfoInSnippet = new[] { "LicenseInfoInSnippet" },
+                LicenseInfoInSnippet = ["LicenseInfoInSnippet"],
                 LicenseComments = "LicenseComments",
                 CopyrightText = "Copyright",
                 Comment = "Comment",
                 Name = "Name",
-                AttributionText = new[] { "AttributionText" }
+                AttributionText = ["AttributionText"]
             }
         };
 

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxAnnotationTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxAnnotationTests.cs
@@ -102,8 +102,7 @@ public class SpdxAnnotationTests
 
         annotations = SpdxAnnotation.Enhance(
             annotations,
-            new[]
-            {
+            [
                 new SpdxAnnotation
                 {
                     Id = "SPDXRef-Annotation1",
@@ -119,7 +118,7 @@ public class SpdxAnnotationTests
                     Date = "2023-11-20T12:34:23Z",
                     Type = SpdxAnnotationType.Other
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, annotations.Length);
         Assert.AreEqual("SPDXRef-Annotation1", annotations[0].Id);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxChecksumTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxChecksumTests.cs
@@ -92,8 +92,7 @@ public class SpdxChecksumTests
 
         checksums = SpdxChecksum.Enhance(
             checksums,
-            new[]
-            {
+            [
                 new SpdxChecksum
                 {
                     Algorithm = SpdxChecksumAlgorithm.Sha1,
@@ -104,7 +103,7 @@ public class SpdxChecksumTests
                     Algorithm = SpdxChecksumAlgorithm.Md5,
                     Value = "624c1abb3664f4b35547e7c73864ad24"
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, checksums.Length);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, checksums[0].Algorithm);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxCreationInformationTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxCreationInformationTests.cs
@@ -28,7 +28,7 @@ public class SpdxCreationInformationTests
     {
         var c1 = new SpdxCreationInformation
         {
-            Creators = new [] { "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()", "Person: Jane Doe ()" },
+            Creators = ["Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()", "Person: Jane Doe ()"],
             Created = "2010-01-29T18:30:22Z",
             Comment = "This package has been shipped in source and binary form.",
             LicenseListVersion = "3.9"
@@ -47,7 +47,7 @@ public class SpdxCreationInformationTests
     {
         var info = new SpdxCreationInformation
         {
-            Creators = new[] { "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()" },
+            Creators = ["Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()"],
             Created = "2010-01-29T18:30:22Z",
             Comment = "This package has been shipped in source and binary form."
         };
@@ -55,7 +55,7 @@ public class SpdxCreationInformationTests
         info.Enhance(
             new SpdxCreationInformation
             {
-                Creators = new[] { "Person: Jane Doe ()" },
+                Creators = ["Person: Jane Doe ()"],
                 LicenseListVersion = "3.9"
             });
 

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxDocumentTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxDocumentTests.cs
@@ -32,8 +32,8 @@ public class SpdxDocumentTests
             Id = "SPDXRef-DOCUMENT",
             Name = "Test Document",
             DocumentNamespace = "http://example.com/SpdxDocument",
-            Packages = new[]
-            {
+            Packages =
+            [
                 new SpdxPackage
                 {
                     Id = "SPDXRef-Package1"
@@ -46,9 +46,9 @@ public class SpdxDocumentTests
                 {
                     Id = "SPDXRef-Package3"
                 }
-            },
-            Relationships = new[]
-            {
+            ],
+            Relationships =
+            [
                 new SpdxRelationship
                 {
                     Id = "SPDXRef-DOCUMENT",
@@ -61,8 +61,8 @@ public class SpdxDocumentTests
                     RelationshipType = SpdxRelationshipType.DescribedBy,
                     RelatedSpdxElement = "SPDXRef-DOCUMENT"
                 }
-            },
-            Describes = new[] { "SPDXRef-Package1" }
+            ],
+            Describes = ["SPDXRef-Package1"]
         };
 
         // Act
@@ -80,19 +80,19 @@ public class SpdxDocumentTests
         var d1 = new SpdxDocument
         {
             Name = "DemaConsulting.SpdxModel-0.0.0",
-            Packages = new[]
-            {
+            Packages =
+            [
                 new SpdxPackage
                 {
                     Id = "SPDXRef-Package1",
                     Name = "DemaConsulting.SpdxModel",
                     Version = "0.0.0"
                 }
-            },
-            Describes = new[]
-            {
+            ],
+            Describes =
+            [
                 "SPDXRef-Package1"
-            }
+            ]
         };
 
         var d2 = new SpdxDocument
@@ -100,37 +100,37 @@ public class SpdxDocumentTests
             Id = "SPDXRef-DOCUMENT",
             Version = "SPDX-2.2",
             Name = "DemaConsulting.SpdxModel-0.0.0",
-            Packages = new[]
-            {
+            Packages =
+            [
                 new SpdxPackage
                 {
                     Id = "SPDXRef-Package-SpdxModel",
                     Name = "DemaConsulting.SpdxModel",
                     Version = "0.0.0"
                 }
-            },
-            Describes = new[]
-            {
+            ],
+            Describes =
+            [
                 "SPDXRef-Package-SpdxModel"
-            }
+            ]
         };
 
         var d3 = new SpdxDocument
         {
             Name = "SomePackage-1.2.3",
-            Packages = new[]
-            {
+            Packages =
+            [
                 new SpdxPackage
                 {
                     Id = "SPDXRef-Package1",
                     Name = "SomePackage",
                     Version = "1.2.3"
                 }
-            },
-            Describes = new[]
-            {
+            ],
+            Describes =
+            [
                 "SPDXRef-Package1"
-            }
+            ]
         };
 
         // Assert documents compare to themselves
@@ -158,19 +158,19 @@ public class SpdxDocumentTests
             Id = "SPDXRef-DOCUMENT",
             Version = "SPDX-2.2",
             Name = "DemaConsulting.SpdxModel-0.0.0",
-            Packages = new[]
-            {
+            Packages =
+            [
                 new SpdxPackage
                 {
                     Id = "SPDXRef-Package-SpdxModel",
                     Name = "DemaConsulting.SpdxModel",
                     Version = "0.0.0"
                 }
-            },
-            Describes = new[]
-            {
+            ],
+            Describes =
+            [
                 "SPDXRef-Package-SpdxModel"
-            }
+            ]
         };
 
         var d2 = d1.DeepCopy();
@@ -208,8 +208,8 @@ public class SpdxDocumentTests
             Id = "SPDXRef-DOCUMENT",
             Name = "Test Document",
             DocumentNamespace = "http://example.com/SpdxDocument",
-            Packages = new[]
-            {
+            Packages =
+            [
                 new SpdxPackage
                 {
                     Id = "SPDXRef-Package1"
@@ -218,17 +218,17 @@ public class SpdxDocumentTests
                 {
                     Id = "SPDXRef-Package1"
                 }
-            },
-            Relationships = new[]
-            {
+            ],
+            Relationships =
+            [
                 new SpdxRelationship
                 {
                     Id = "SPDXRef-DOCUMENT",
                     RelationshipType = SpdxRelationshipType.Describes,
                     RelatedSpdxElement = "SPDXRef-Package1"
                 }
-            },
-            Describes = new[] { "SPDXRef-Package1" }
+            ],
+            Describes = ["SPDXRef-Package1"]
         };
 
         // Perform validation
@@ -249,23 +249,23 @@ public class SpdxDocumentTests
             Id = "SPDXRef-DOCUMENT",
             Name = "Test Document",
             DocumentNamespace = "http://example.com/SpdxDocument",
-            Packages = new[]
-            {
+            Packages =
+            [
                 new SpdxPackage
                 {
                     Id = "SPDXRef-Package1"
                 }
-            },
-            Relationships = new[]
-            {
+            ],
+            Relationships =
+            [
                 new SpdxRelationship
                 {
                     Id = "SPDXRef-DOCUMENT",
                     RelationshipType = SpdxRelationshipType.Describes,
                     RelatedSpdxElement = "SPDXRef-Package2"
                 }
-            },
-            Describes = new[] { "SPDXRef-Package1" }
+            ],
+            Describes = ["SPDXRef-Package1"]
         };
 
         // Perform validation

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxExternalDocumentReferenceTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxExternalDocumentReferenceTests.cs
@@ -112,8 +112,7 @@ public class SpdxExternalDocumentReferenceTests
 
         references = SpdxExternalDocumentReference.Enhance(
             references,
-            new[]
-            {
+            [
                 new SpdxExternalDocumentReference
                 {
                     Checksum = new SpdxChecksum
@@ -133,7 +132,7 @@ public class SpdxExternalDocumentReferenceTests
                     },
                     Document = "http://demo.com/some-document"
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, references.Length);
         Assert.AreEqual("DocumentRef-spdx-tool-1.2", references[0].ExternalDocumentId);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxExternalReferenceTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxExternalReferenceTests.cs
@@ -99,8 +99,7 @@ public class SpdxExternalReferenceTests
 
         references = SpdxExternalReference.Enhance(
             references,
-            new[]
-            {
+            [
                 new SpdxExternalReference
                 {
                     Category = SpdxReferenceCategory.Security,
@@ -114,7 +113,7 @@ public class SpdxExternalReferenceTests
                     Type = "purl",
                     Locator = "pkg:nuget/SomePackage@0.0.0"
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, references.Length);
         Assert.AreEqual(SpdxReferenceCategory.Security, references[0].Category);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxExtractedLicensingInfoTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxExtractedLicensingInfoTests.cs
@@ -94,8 +94,7 @@ public class SpdxExtractedLicensingInfoTests
 
         infos = SpdxExtractedLicensingInfo.Enhance(
             infos,
-            new[]
-            {
+            [
                 new SpdxExtractedLicensingInfo
                 {
                     LicenseId = "LicenseRef-1",
@@ -107,7 +106,7 @@ public class SpdxExtractedLicensingInfoTests
                     LicenseId = "LicenseRef-2",
                     ExtractedText = "Some Random License"
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, infos.Length);
         Assert.AreEqual("LicenseRef-1", infos[0].LicenseId);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxFileTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxFileTests.cs
@@ -29,22 +29,22 @@ public class SpdxFileTests
         var f1 = new SpdxFile
         {
             FileName = "./file1.txt",
-            Checksums = new[]
-            {
+            Checksums =
+            [
                 new SpdxChecksum
                 {
                     Algorithm = SpdxChecksumAlgorithm.Sha1,
                     Value = "85ed0817af83a24ad8da68c2b5094de69833983c"
                 }
-            }
+            ]
         };
 
         var f2 = new SpdxFile
         {
             Id = "SPDXRef-File1",
             FileName = "./file1.txt",
-            Checksums = new[]
-            {
+            Checksums =
+            [
                 new SpdxChecksum
                 {
                     Algorithm = SpdxChecksumAlgorithm.Sha1,
@@ -55,21 +55,21 @@ public class SpdxFileTests
                     Algorithm = SpdxChecksumAlgorithm.Md5,
                     Value = "624c1abb3664f4b35547e7c73864ad24"
                 }
-            },
+            ],
             Comment = "File 1"
         };
 
         var f3 = new SpdxFile
         {
             FileName = "./file2.txt",
-            Checksums = new[]
-            {
+            Checksums =
+            [
                 new SpdxChecksum
                 {
                     Algorithm = SpdxChecksumAlgorithm.Sha1,
                     Value = "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
                 }
-            }
+            ]
         };
 
         // Assert files compare to themselves
@@ -96,8 +96,8 @@ public class SpdxFileTests
         {
             Id = "SPDXRef-File1",
             FileName = "./file1.txt",
-            Checksums = new[]
-            {
+            Checksums =
+            [
                 new SpdxChecksum
                 {
                     Algorithm = SpdxChecksumAlgorithm.Sha1,
@@ -108,7 +108,7 @@ public class SpdxFileTests
                     Algorithm = SpdxChecksumAlgorithm.Md5,
                     Value = "624c1abb3664f4b35547e7c73864ad24"
                 }
-            },
+            ],
             Comment = "File 1"
         };
 
@@ -128,27 +128,26 @@ public class SpdxFileTests
             new SpdxFile
             {
                 FileName = "./file1.txt",
-                Checksums = new[]
-                {
+                Checksums =
+                [
                     new SpdxChecksum
                     {
                         Algorithm = SpdxChecksumAlgorithm.Sha1,
                         Value = "85ed0817af83a24ad8da68c2b5094de69833983c"
                     }
-                }
+                ]
             }
         };
 
         files = SpdxFile.Enhance(
             files,
-            new[]
-            {
+            [
                 new SpdxFile
                 {
                     Id = "SPDXRef-File1",
                     FileName = "./file1.txt",
-                    Checksums = new[]
-                    {
+                    Checksums =
+                    [
                         new SpdxChecksum
                         {
                             Algorithm = SpdxChecksumAlgorithm.Sha1,
@@ -159,22 +158,22 @@ public class SpdxFileTests
                             Algorithm = SpdxChecksumAlgorithm.Md5,
                             Value = "624c1abb3664f4b35547e7c73864ad24"
                         }
-                    },
+                    ],
                     Comment = "File 1"
                 },
                 new SpdxFile
                 {
                     FileName = "./file2.txt",
-                    Checksums = new[]
-                    {
+                    Checksums =
+                    [
                         new SpdxChecksum
                         {
                             Algorithm = SpdxChecksumAlgorithm.Sha1,
                             Value = "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
                         }
-                    }
+                    ]
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, files.Length);
         Assert.AreEqual("SPDXRef-File1", files[0].Id);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxPackageTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxPackageTests.cs
@@ -97,8 +97,7 @@ public class SpdxPackageTests
 
         packages = SpdxPackage.Enhance(
             packages,
-            new[]
-            {
+            [
                 new SpdxPackage
                 {
                     Id = "SPDXRef-Package-SpdxModel",
@@ -111,7 +110,7 @@ public class SpdxPackageTests
                     Name = "SomePackage",
                     Version = "1.2.3"
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, packages.Length);
         Assert.AreEqual("SPDXRef-Package1", packages[0].Id);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxPackageVerificationCodeTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxPackageVerificationCodeTests.cs
@@ -33,7 +33,7 @@ public class SpdxPackageVerificationCodeTests
 
         var v2 = new SpdxPackageVerificationCode
         {
-            ExcludedFiles = new[] { "./package.spdx" },
+            ExcludedFiles = ["./package.spdx"],
             Value = "d6a770ba38583ed4bb4525bd96e50461655d2758"
         };
 
@@ -64,7 +64,7 @@ public class SpdxPackageVerificationCodeTests
     {
         var v1 = new SpdxPackageVerificationCode
         {
-            ExcludedFiles = new[] { "./package.spdx" },
+            ExcludedFiles = ["./package.spdx"],
             Value = "d6a770ba38583ed4bb4525bd96e50461655d2758"
         };
 
@@ -87,7 +87,7 @@ public class SpdxPackageVerificationCodeTests
         info.Enhance(
             new SpdxPackageVerificationCode
             {
-                ExcludedFiles = new[] { "./package.spdx" },
+                ExcludedFiles = ["./package.spdx"],
                 Value = "d6a770ba38583ed4bb4525bd96e50461655d2758"
             });
 

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxRelationshipTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxRelationshipTests.cs
@@ -141,8 +141,7 @@ public class SpdxRelationshipTests
 
         relationships = SpdxRelationship.Enhance(
             relationships,
-            new[]
-            {
+            [
                 new SpdxRelationship
                 {
                     Id = "SPDXRef-Package1",
@@ -156,7 +155,7 @@ public class SpdxRelationshipTests
                     RelationshipType = SpdxRelationshipType.DevToolOf,
                     RelatedSpdxElement = "SPDXRef-Package4"
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, relationships.Length);
         Assert.AreEqual("SPDXRef-Package1", relationships[0].Id);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxSnippetTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxSnippetTests.cs
@@ -99,8 +99,7 @@ public class SpdxSnippetTests
 
         snippets = SpdxSnippet.Enhance(
             snippets,
-            new[]
-            {
+            [
                 new SpdxSnippet
                 {
                     SnippetFromFile = "SPDXRef-File1",
@@ -115,7 +114,7 @@ public class SpdxSnippetTests
                     SnippetByteStart = 10,
                     SnippetByteEnd = 40
                 }
-            });
+            ]);
 
         Assert.AreEqual(2, snippets.Length);
         Assert.AreEqual("SPDXRef-File1", snippets[0].SnippetFromFile);

--- a/test/DemaConsulting.SpdxModel.Tests/Transforms/SpdxRelationshipsTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/Transforms/SpdxRelationshipsTests.cs
@@ -9,37 +9,39 @@ public class SpdxRelationshipsTests
     /// <summary>
     /// Test SPDX document for relationships.
     /// </summary>
-    private const string Contents = "{\r\n" +
-                                    "  \"files\": [],\r\n" +
-                                    "  \"packages\": [" +
-                                    "    {\r\n" +
-                                    "      \"SPDXID\": \"SPDXRef-Package-1\",\r\n" +
-                                    "      \"name\": \"Test Package\",\r\n" +
-                                    "      \"versionInfo\": \"1.0.0\",\r\n" +
-                                    "      \"packageFileName\": \"package1.zip\",\r\n" +
-                                    "      \"downloadLocation\": \"https://github.com/demaconsulting/SpdxTool\",\r\n" +
-                                    "      \"licenseConcluded\": \"MIT\"\r\n" +
-                                    "    },\r\n" +
-                                    "    {\r\n" +
-                                    "      \"SPDXID\": \"SPDXRef-Package-2\",\r\n" +
-                                    "      \"name\": \"Another Test Package\",\r\n" +
-                                    "      \"versionInfo\": \"2.0.0\",\r\n" +
-                                    "      \"packageFileName\": \"package2.tar\",\r\n" +
-                                    "      \"downloadLocation\": \"https://github.com/demaconsulting/SpdxModel\",\r\n" +
-                                    "      \"licenseConcluded\": \"MIT\"\r\n" +
-                                    "    }\r\n" +
-                                    "  ],\r\n" +
-                                    "  \"spdxVersion\": \"SPDX-2.2\",\r\n" +
-                                    "  \"dataLicense\": \"CC0-1.0\",\r\n" +
-                                    "  \"SPDXID\": \"SPDXRef-DOCUMENT\",\r\n" +
-                                    "  \"name\": \"Test Document\",\r\n" +
-                                    "  \"documentNamespace\": \"https://sbom.spdx.org\",\r\n" +
-                                    "  \"creationInfo\": {\r\n" +
-                                    "    \"created\": \"2021-10-01T00:00:00Z\",\r\n" +
-                                    "    \"creators\": [ \"Person: Malcolm Nixon\" ]\r\n" +
-                                    "  },\r\n" +
-                                    "  \"documentDescribes\": [ \"SPDXRef-Package-1\" ]\r\n" +
-                                    "}";
+    private const string Contents = 
+        """
+        {
+          "files": [],
+          "packages": [    {
+              "SPDXID": "SPDXRef-Package-1",
+              "name": "Test Package",
+              "versionInfo": "1.0.0",
+              "packageFileName": "package1.zip",
+              "downloadLocation": "https://github.com/demaconsulting/SpdxTool",
+              "licenseConcluded": "MIT"
+            },
+            {
+              "SPDXID": "SPDXRef-Package-2",
+              "name": "Another Test Package",
+              "versionInfo": "2.0.0",
+              "packageFileName": "package2.tar",
+              "downloadLocation": "https://github.com/demaconsulting/SpdxModel",
+              "licenseConcluded": "MIT"
+            }
+          ],
+          "spdxVersion": "SPDX-2.2",
+          "dataLicense": "CC0-1.0",
+          "SPDXID": "SPDXRef-DOCUMENT",
+          "name": "Test Document",
+          "documentNamespace": "https://sbom.spdx.org",
+          "creationInfo": {
+            "created": "2021-10-01T00:00:00Z",
+            "creators": [ "Person: Malcolm Nixon" ]
+          },
+          "documentDescribes": [ "SPDXRef-Package-1" ]
+        }
+        """;
 
     [TestMethod]
     public void AddRelationshipBadId()
@@ -150,15 +152,14 @@ public class SpdxRelationshipsTests
         // Act
         SpdxRelationships.Add(
             document,
-            new[]
-            {
+            [
                 new SpdxRelationship
                 {
                     Id = "SPDXRef-Package-1",
                     RelatedSpdxElement = "SPDXRef-Package-2",
                     RelationshipType = SpdxRelationshipType.DependsOn
                 }
-            });
+            ]);
 
         // Assert
         Assert.AreEqual(1, document.Relationships.Length);
@@ -176,8 +177,7 @@ public class SpdxRelationshipsTests
         // Act
         SpdxRelationships.Add(
             document,
-            new[]
-            {
+            [
                 new SpdxRelationship
                 {
                     Id = "SPDXRef-Package-1",
@@ -190,7 +190,7 @@ public class SpdxRelationshipsTests
                     RelatedSpdxElement = "SPDXRef-Package-2",
                     RelationshipType = SpdxRelationshipType.DependsOn
                 }
-            });
+            ]);
 
         // Assert
         Assert.AreEqual(1, document.Relationships.Length);
@@ -214,15 +214,14 @@ public class SpdxRelationshipsTests
             });
 
         // Act
-        SpdxRelationships.Add(document, new[]
-            {
+        SpdxRelationships.Add(document, [
                 new SpdxRelationship
                 {
                     Id = "SPDXRef-Package-1",
                     RelatedSpdxElement = "SPDXRef-Package-2",
                     RelationshipType = SpdxRelationshipType.BuildToolOf
                 }
-            },
+            ],
             true);
 
         // Assert


### PR DESCRIPTION
This PR drops .NET 6 support and converts the project to take advantage of C# 12 features.