### PR TITLE
Add multitarget support for DotNet 8, 9, and 10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "dotnet-sonarscanner": {
-      "version": "10.2.0",
+      "version": "11.0.0",
       "commands": [
         "dotnet-sonarscanner"
       ]
     },
     "microsoft.sbom.dotnettool": {
-      "version": "4.0.3",
+      "version": "4.1.4",
       "commands": [
         "sbom-tool"
       ]
     },
     "demaconsulting.spdxtool": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "commands": [
         "spdx-tool"
       ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,16 +24,17 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup dotnet 6/8
-        uses: actions/setup-dotnet@v4
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            6.x
             8.x
+            9.x
+            10.x
 
       - name: Restore Tools
         run: >
@@ -117,7 +118,7 @@ jobs:
           --property:PackageVersion=${{ inputs.version }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: artifacts-${{ inputs.os }}
           path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,16 +40,16 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Setup dotnet 8
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.x
+            10.x
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: artifacts-ubuntu-latest
           path: artifacts

--- a/src/DemaConsulting.SpdxModel/DemaConsulting.SpdxModel.csproj
+++ b/src/DemaConsulting.SpdxModel/DemaConsulting.SpdxModel.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -48,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="9.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/DemaConsulting.SpdxModel.Tests/DemaConsulting.SpdxModel.Tests.csproj
+++ b/test/DemaConsulting.SpdxModel.Tests/DemaConsulting.SpdxModel.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <LangVersion>12</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -26,9 +27,9 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserialize22.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserialize22.cs
@@ -45,7 +45,7 @@ public class Spdx2JsonDeserialize22
         doc.Validate(issues);
 
         // Assert: Verify that there are no validation issues
-        Assert.AreEqual(0, issues.Count);
+        Assert.IsEmpty(issues);
 
         // Assert: Verify the document properties
         Assert.AreEqual("SPDX-Tools-v2.0", doc.Name);
@@ -53,7 +53,7 @@ public class Spdx2JsonDeserialize22
         Assert.AreEqual("http://spdx.org/spdxdocs/spdx-example-json-2.2-444504E0-4F89-41D3-9A0C-0305E82C3301",
             doc.DocumentNamespace);
         Assert.AreEqual("This document was created using SPDX 2.0 using licenses from the web site.", doc.Comment);
-        Assert.AreEqual(3, doc.CreationInformation.Creators.Length);
+        Assert.HasCount(3, doc.CreationInformation.Creators);
         Assert.AreEqual("Tool: LicenseFind-1.0", doc.CreationInformation.Creators[0]);
         Assert.AreEqual("Organization: ExampleCodeInspect ()", doc.CreationInformation.Creators[1]);
         Assert.AreEqual("Person: Jane Doe ()", doc.CreationInformation.Creators[2]);
@@ -62,7 +62,7 @@ public class Spdx2JsonDeserialize22
         Assert.AreEqual("3.9", doc.CreationInformation.LicenseListVersion);
 
         // Assert: Verify external document references
-        Assert.AreEqual(1, doc.ExternalDocumentReferences.Length);
+        Assert.HasCount(1, doc.ExternalDocumentReferences);
         Assert.AreEqual("DocumentRef-spdx-tool-1.2", doc.ExternalDocumentReferences[0].ExternalDocumentId);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, doc.ExternalDocumentReferences[0].Checksum.Algorithm);
         Assert.AreEqual("d6a770ba38583ed4bb4525bd96e50461655d2759", doc.ExternalDocumentReferences[0].Checksum.Value);
@@ -70,7 +70,7 @@ public class Spdx2JsonDeserialize22
             doc.ExternalDocumentReferences[0].Document);
 
         // Assert: Verify extracted licensing info
-        Assert.AreEqual(5, doc.ExtractedLicensingInfo.Length);
+        Assert.HasCount(5, doc.ExtractedLicensingInfo);
         Assert.AreEqual("LicenseRef-Beerware-4.2", doc.ExtractedLicensingInfo[0].LicenseId);
         StringAssert.StartsWith(doc.ExtractedLicensingInfo[0].ExtractedText, "\"THE BEER-WARE LICENSE\"");
         Assert.AreEqual("LicenseRef-4", doc.ExtractedLicensingInfo[1].LicenseId);
@@ -79,7 +79,7 @@ public class Spdx2JsonDeserialize22
         Assert.AreEqual("LicenseRef-3", doc.ExtractedLicensingInfo[2].LicenseId);
         StringAssert.StartsWith(doc.ExtractedLicensingInfo[2].ExtractedText, "The CyberNeko Software License");
         Assert.AreEqual("CyberNeko License", doc.ExtractedLicensingInfo[2].Name);
-        Assert.AreEqual(2, doc.ExtractedLicensingInfo[2].CrossReferences.Length);
+        Assert.HasCount(2, doc.ExtractedLicensingInfo[2].CrossReferences);
         Assert.AreEqual("http://people.apache.org/~andyc/neko/LICENSE",
             doc.ExtractedLicensingInfo[2].CrossReferences[0]);
         Assert.AreEqual("http://justasample.url.com", doc.ExtractedLicensingInfo[2].CrossReferences[1]);
@@ -90,7 +90,7 @@ public class Spdx2JsonDeserialize22
         StringAssert.StartsWith(doc.ExtractedLicensingInfo[4].ExtractedText, "/*\n * (c) Copyright 2000, 2001, 2002");
 
         // Assert: Verify annotations
-        Assert.AreEqual(3, doc.Annotations.Length);
+        Assert.HasCount(3, doc.Annotations);
         Assert.AreEqual("Person: Jane Doe ()", doc.Annotations[0].Annotator);
         Assert.AreEqual("2010-01-29T18:30:22Z", doc.Annotations[0].Date);
         Assert.AreEqual(SpdxAnnotationType.Other, doc.Annotations[0].Type);
@@ -105,19 +105,19 @@ public class Spdx2JsonDeserialize22
         StringAssert.StartsWith(doc.Annotations[2].Comment, "This is just an example");
 
         // Assert: Verify files
-        Assert.AreEqual(4, doc.Files.Length);
+        Assert.HasCount(4, doc.Files);
         Assert.AreEqual("SPDXRef-DoapSource", doc.Files[0].Id);
         Assert.AreEqual("./src/org/spdx/parser/DOAPProject.java", doc.Files[0].FileName);
-        Assert.AreEqual(1, doc.Files[0].FileTypes.Length);
+        Assert.HasCount(1, doc.Files[0].FileTypes);
         Assert.IsTrue(doc.Files[0].FileTypes.Contains(SpdxFileType.Source));
-        Assert.AreEqual(1, doc.Files[0].Checksums.Length);
+        Assert.HasCount(1, doc.Files[0].Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, doc.Files[0].Checksums[0].Algorithm);
         Assert.AreEqual("2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", doc.Files[0].Checksums[0].Value);
         Assert.AreEqual("Apache-2.0", doc.Files[0].ConcludedLicense);
-        Assert.AreEqual(1, doc.Files[0].LicenseInfoInFiles.Length);
+        Assert.HasCount(1, doc.Files[0].LicenseInfoInFiles);
         Assert.AreEqual("Apache-2.0", doc.Files[0].LicenseInfoInFiles[0]);
         Assert.AreEqual("Copyright 2010, 2011 Source Auditor Inc.", doc.Files[0].CopyrightText);
-        Assert.AreEqual(5, doc.Files[0].Contributors.Length);
+        Assert.HasCount(5, doc.Files[0].Contributors);
         Assert.AreEqual("Protecode Inc.", doc.Files[0].Contributors[0]);
         Assert.AreEqual("SPDX Technical Team Members", doc.Files[0].Contributors[1]);
         Assert.AreEqual("Open Logic Inc.", doc.Files[0].Contributors[2]);
@@ -126,19 +126,19 @@ public class Spdx2JsonDeserialize22
         Assert.AreEqual("This file is used by Jena", doc.Files[1].Comment);
         StringAssert.StartsWith(doc.Files[1].Notice, "Apache Commons Lang\nCopyright 2001-2011");
         Assert.AreEqual("This license is used by Jena", doc.Files[2].LicenseComments);
-        Assert.AreEqual(1, doc.Files[3].Annotations.Length);
+        Assert.HasCount(1, doc.Files[3].Annotations);
         Assert.AreEqual("Person: File Commenter", doc.Files[3].Annotations[0].Annotator);
         Assert.AreEqual("2011-01-29T18:30:22Z", doc.Files[3].Annotations[0].Date);
         Assert.AreEqual(SpdxAnnotationType.Other, doc.Files[3].Annotations[0].Type);
         Assert.AreEqual("File level annotation", doc.Files[3].Annotations[0].Comment);
-        Assert.AreEqual(2, doc.Files[3].Checksums.Length);
+        Assert.HasCount(2, doc.Files[3].Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Md5, doc.Files[3].Checksums[0].Algorithm);
         Assert.AreEqual("624c1abb3664f4b35547e7c73864ad24", doc.Files[3].Checksums[0].Value);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, doc.Files[3].Checksums[1].Algorithm);
         Assert.AreEqual("d6a770ba38583ed4bb4525bd96e50461655d2758", doc.Files[3].Checksums[1].Value);
 
         // Assert: Verify snippets
-        Assert.AreEqual(1, doc.Snippets.Length);
+        Assert.HasCount(1, doc.Snippets);
         Assert.AreEqual("SPDXRef-Snippet", doc.Snippets[0].Id);
         Assert.AreEqual("SPDXRef-DoapSource", doc.Snippets[0].SnippetFromFile);
         Assert.AreEqual(310, doc.Snippets[0].SnippetByteStart);
@@ -146,7 +146,7 @@ public class Spdx2JsonDeserialize22
         Assert.AreEqual(5, doc.Snippets[0].SnippetLineStart);
         Assert.AreEqual(23, doc.Snippets[0].SnippetLineEnd);
         Assert.AreEqual("GPL-2.0-only", doc.Snippets[0].ConcludedLicense);
-        Assert.AreEqual(1, doc.Snippets[0].LicenseInfoInSnippet.Length);
+        Assert.HasCount(1, doc.Snippets[0].LicenseInfoInSnippet);
         Assert.AreEqual("GPL-2.0-only", doc.Snippets[0].LicenseInfoInSnippet[0]);
         StringAssert.StartsWith(doc.Snippets[0].LicenseComments, "The concluded license was taken");
         Assert.AreEqual("Copyright 2008-2010 John Smith", doc.Snippets[0].CopyrightText);
@@ -154,7 +154,7 @@ public class Spdx2JsonDeserialize22
         Assert.AreEqual("from linux kernel", doc.Snippets[0].Name);
 
         // Assert: Verify relationships
-        Assert.AreEqual(9, doc.Relationships.Length);
+        Assert.HasCount(9, doc.Relationships);
         Assert.AreEqual("SPDXRef-DOCUMENT", doc.Relationships[0].Id);
         Assert.AreEqual("SPDXRef-Package", doc.Relationships[0].RelatedSpdxElement);
         Assert.AreEqual(SpdxRelationshipType.Contains, doc.Relationships[0].RelationshipType);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserialize23.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserialize23.cs
@@ -45,7 +45,7 @@ public class Spdx2JsonDeserialize23
         doc.Validate(issues);
 
         // Assert: Verify that there are no validation issues
-        Assert.AreEqual(0, issues.Count);
+        Assert.IsEmpty(issues);
 
         // Assert: Verify document
         Assert.AreEqual("SPDX-Tools-v2.0", doc.Name);
@@ -53,7 +53,7 @@ public class Spdx2JsonDeserialize23
         Assert.AreEqual("http://spdx.org/spdxdocs/spdx-example-json-2.3-444504E0-4F89-41D3-9A0C-0305E82C3301",
             doc.DocumentNamespace);
         Assert.AreEqual("This document was created using SPDX 2.0 using licenses from the web site.", doc.Comment);
-        Assert.AreEqual(3, doc.CreationInformation.Creators.Length);
+        Assert.HasCount(3, doc.CreationInformation.Creators);
         Assert.AreEqual("Tool: LicenseFind-1.0", doc.CreationInformation.Creators[0]);
         Assert.AreEqual("Organization: ExampleCodeInspect ()", doc.CreationInformation.Creators[1]);
         Assert.AreEqual("Person: Jane Doe ()", doc.CreationInformation.Creators[2]);
@@ -62,7 +62,7 @@ public class Spdx2JsonDeserialize23
         Assert.AreEqual("3.17", doc.CreationInformation.LicenseListVersion);
 
         // Assert: Verify external document references
-        Assert.AreEqual(1, doc.ExternalDocumentReferences.Length);
+        Assert.HasCount(1, doc.ExternalDocumentReferences);
         Assert.AreEqual("DocumentRef-spdx-tool-1.2", doc.ExternalDocumentReferences[0].ExternalDocumentId);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, doc.ExternalDocumentReferences[0].Checksum.Algorithm);
         Assert.AreEqual("d6a770ba38583ed4bb4525bd96e50461655d2759", doc.ExternalDocumentReferences[0].Checksum.Value);
@@ -70,7 +70,7 @@ public class Spdx2JsonDeserialize23
             doc.ExternalDocumentReferences[0].Document);
 
         // Assert: Verify extracted licensing info
-        Assert.AreEqual(5, doc.ExtractedLicensingInfo.Length);
+        Assert.HasCount(5, doc.ExtractedLicensingInfo);
         Assert.AreEqual("LicenseRef-1", doc.ExtractedLicensingInfo[0].LicenseId);
         StringAssert.StartsWith(doc.ExtractedLicensingInfo[0].ExtractedText,
             "/*\n * (c) Copyright 2000, 2001, 2002, 2003");
@@ -83,20 +83,20 @@ public class Spdx2JsonDeserialize23
         StringAssert.StartsWith(
             doc.ExtractedLicensingInfo[3].ExtractedText, "\"THE BEER-WARE LICENSE\" (Revision 42)");
         Assert.AreEqual("Beer-Ware License (Version 42)", doc.ExtractedLicensingInfo[3].Name);
-        Assert.AreEqual(1, doc.ExtractedLicensingInfo[3].CrossReferences.Length);
+        Assert.HasCount(1, doc.ExtractedLicensingInfo[3].CrossReferences);
         Assert.AreEqual("http://people.freebsd.org/~phk/", doc.ExtractedLicensingInfo[3].CrossReferences[0]);
         StringAssert.StartsWith(doc.ExtractedLicensingInfo[3].Comment, "The beerware license has");
         Assert.AreEqual("LicenseRef-3", doc.ExtractedLicensingInfo[4].LicenseId);
         StringAssert.StartsWith(doc.ExtractedLicensingInfo[4].ExtractedText, "The CyberNeko Software License");
         Assert.AreEqual("CyberNeko License", doc.ExtractedLicensingInfo[4].Name);
-        Assert.AreEqual(2, doc.ExtractedLicensingInfo[4].CrossReferences.Length);
+        Assert.HasCount(2, doc.ExtractedLicensingInfo[4].CrossReferences);
         Assert.AreEqual("http://people.apache.org/~andyc/neko/LICENSE",
             doc.ExtractedLicensingInfo[4].CrossReferences[0]);
         Assert.AreEqual("http://justasample.url.com", doc.ExtractedLicensingInfo[4].CrossReferences[1]);
         StringAssert.StartsWith(doc.ExtractedLicensingInfo[4].Comment, "This is the CyperNeko License");
 
         // Assert: Verify annotations
-        Assert.AreEqual(3, doc.Annotations.Length);
+        Assert.HasCount(3, doc.Annotations);
         Assert.AreEqual("Person: Jane Doe ()", doc.Annotations[0].Annotator);
         Assert.AreEqual("2010-01-29T18:30:22Z", doc.Annotations[0].Date);
         Assert.AreEqual(SpdxAnnotationType.Other, doc.Annotations[0].Type);
@@ -111,19 +111,19 @@ public class Spdx2JsonDeserialize23
         StringAssert.StartsWith(doc.Annotations[2].Comment, "Another example reviewer.");
 
         // Assert: Verify files
-        Assert.AreEqual(5, doc.Files.Length);
+        Assert.HasCount(5, doc.Files);
         Assert.AreEqual("SPDXRef-DoapSource", doc.Files[0].Id);
         Assert.AreEqual("./src/org/spdx/parser/DOAPProject.java", doc.Files[0].FileName);
-        Assert.AreEqual(1, doc.Files[0].FileTypes.Length);
+        Assert.HasCount(1, doc.Files[0].FileTypes);
         Assert.IsTrue(doc.Files[0].FileTypes.Contains(SpdxFileType.Source));
-        Assert.AreEqual(1, doc.Files[0].Checksums.Length);
+        Assert.HasCount(1, doc.Files[0].Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, doc.Files[0].Checksums[0].Algorithm);
         Assert.AreEqual("2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", doc.Files[0].Checksums[0].Value);
         Assert.AreEqual("Apache-2.0", doc.Files[0].ConcludedLicense);
-        Assert.AreEqual(1, doc.Files[0].LicenseInfoInFiles.Length);
+        Assert.HasCount(1, doc.Files[0].LicenseInfoInFiles);
         Assert.AreEqual("Apache-2.0", doc.Files[0].LicenseInfoInFiles[0]);
         Assert.AreEqual("Copyright 2010, 2011 Source Auditor Inc.", doc.Files[0].CopyrightText);
-        Assert.AreEqual(5, doc.Files[0].Contributors.Length);
+        Assert.HasCount(5, doc.Files[0].Contributors);
         Assert.AreEqual("Protecode Inc.", doc.Files[0].Contributors[0]);
         Assert.AreEqual("SPDX Technical Team Members", doc.Files[0].Contributors[1]);
         Assert.AreEqual("Open Logic Inc.", doc.Files[0].Contributors[2]);
@@ -132,14 +132,14 @@ public class Spdx2JsonDeserialize23
         Assert.AreEqual("This file is used by Jena", doc.Files[1].Comment);
         StringAssert.StartsWith(doc.Files[1].Notice, "Apache Commons Lang\nCopyright 2001-2011");
         Assert.AreEqual("This license is used by Jena", doc.Files[2].LicenseComments);
-        Assert.AreEqual(2, doc.Files[4].Checksums.Length);
+        Assert.HasCount(2, doc.Files[4].Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, doc.Files[4].Checksums[0].Algorithm);
         Assert.AreEqual("d6a770ba38583ed4bb4525bd96e50461655d2758", doc.Files[4].Checksums[0].Value);
         Assert.AreEqual(SpdxChecksumAlgorithm.Md5, doc.Files[4].Checksums[1].Algorithm);
         Assert.AreEqual("624c1abb3664f4b35547e7c73864ad24", doc.Files[4].Checksums[1].Value);
 
         // Assert: Verify snippets
-        Assert.AreEqual(1, doc.Snippets.Length);
+        Assert.HasCount(1, doc.Snippets);
         Assert.AreEqual("SPDXRef-Snippet", doc.Snippets[0].Id);
         Assert.AreEqual("SPDXRef-DoapSource", doc.Snippets[0].SnippetFromFile);
         Assert.AreEqual(310, doc.Snippets[0].SnippetByteStart);
@@ -147,7 +147,7 @@ public class Spdx2JsonDeserialize23
         Assert.AreEqual(5, doc.Snippets[0].SnippetLineStart);
         Assert.AreEqual(23, doc.Snippets[0].SnippetLineEnd);
         Assert.AreEqual("GPL-2.0-only", doc.Snippets[0].ConcludedLicense);
-        Assert.AreEqual(1, doc.Snippets[0].LicenseInfoInSnippet.Length);
+        Assert.HasCount(1, doc.Snippets[0].LicenseInfoInSnippet);
         Assert.AreEqual("GPL-2.0-only", doc.Snippets[0].LicenseInfoInSnippet[0]);
         StringAssert.StartsWith(doc.Snippets[0].LicenseComments, "The concluded license was taken");
         Assert.AreEqual("Copyright 2008-2010 John Smith", doc.Snippets[0].CopyrightText);
@@ -155,7 +155,7 @@ public class Spdx2JsonDeserialize23
         Assert.AreEqual("from linux kernel", doc.Snippets[0].Name);
 
         // Assert: Verify relationships
-        Assert.AreEqual(7, doc.Relationships.Length);
+        Assert.HasCount(7, doc.Relationships);
         Assert.AreEqual("SPDXRef-DOCUMENT", doc.Relationships[0].Id);
         Assert.AreEqual("SPDXRef-Package", doc.Relationships[0].RelatedSpdxElement);
         Assert.AreEqual(SpdxRelationshipType.Contains, doc.Relationships[0].RelationshipType);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeAnnotation.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeAnnotation.cs
@@ -84,7 +84,7 @@ public class Spdx2JsonDeserializeAnnotation
         var annotations = Spdx2JsonDeserializer.DeserializeAnnotations(json);
 
         // Assert: Verify the deserialized array has the expected number of annotations and their properties
-        Assert.AreEqual(2, annotations.Length);
+        Assert.HasCount(2, annotations);
         Assert.AreEqual("2010-01-29T18:30:22Z", annotations[0].Date);
         Assert.AreEqual(SpdxAnnotationType.Other, annotations[0].Type);
         Assert.AreEqual("Person: Jane Doe ()", annotations[0].Annotator);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeChecksum.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeChecksum.cs
@@ -75,7 +75,7 @@ public class Spdx2JsonDeserializeChecksum
         var checksums = Spdx2JsonDeserializer.DeserializeChecksums(json);
 
         // Assert: Verify the deserialized array has the expected properties
-        Assert.AreEqual(2, checksums.Length);
+        Assert.HasCount(2, checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, checksums[0].Algorithm);
         Assert.AreEqual("2fd4e1c67a2d28f123849ee1bb76e7391b93eb12", checksums[0].Value);
         Assert.AreEqual(SpdxChecksumAlgorithm.Md5, checksums[1].Algorithm);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeCreationInformation.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeCreationInformation.cs
@@ -58,7 +58,7 @@ public class Spdx2JsonDeserializeCreationInformation
             "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
             creationInformation.Comment);
         Assert.AreEqual("2010-01-29T18:30:22Z", creationInformation.Created);
-        Assert.AreEqual(3, creationInformation.Creators.Length);
+        Assert.HasCount(3, creationInformation.Creators);
         Assert.AreEqual("Tool: LicenseFind-1.0", creationInformation.Creators[0]);
         Assert.AreEqual("Organization: ExampleCodeInspect ()", creationInformation.Creators[1]);
         Assert.AreEqual("Person: Jane Doe ()", creationInformation.Creators[2]);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeDocument.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeDocument.cs
@@ -83,15 +83,15 @@ public class Spdx2JsonDeserializeDocument
         Assert.AreEqual("This document was created using SPDX 2.0 using licenses from the web site.", document.Comment);
         Assert.AreEqual("http://spdx.org/spdxdocs/spdx-example-json-2.3-444504E0-4F89-41D3-9A0C-0305E82C3301",
             document.DocumentNamespace);
-        Assert.AreEqual(3, document.Describes.Length);
+        Assert.HasCount(3, document.Describes);
         Assert.AreEqual("SPDXRef-File", document.Describes[0]);
         Assert.AreEqual("SPDXRef-File", document.Describes[1]);
         Assert.AreEqual("SPDXRef-Package", document.Describes[2]);
-        Assert.AreEqual(0, document.ExternalDocumentReferences.Length);
-        Assert.AreEqual(0, document.ExtractedLicensingInfo.Length);
-        Assert.AreEqual(0, document.Packages.Length);
-        Assert.AreEqual(0, document.Files.Length);
-        Assert.AreEqual(0, document.Snippets.Length);
-        Assert.AreEqual(0, document.Relationships.Length);
+        Assert.IsEmpty(document.ExternalDocumentReferences);
+        Assert.IsEmpty(document.ExtractedLicensingInfo);
+        Assert.IsEmpty(document.Packages);
+        Assert.IsEmpty(document.Files);
+        Assert.IsEmpty(document.Snippets);
+        Assert.IsEmpty(document.Relationships);
     }
 }

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeExternalDocumentReference.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeExternalDocumentReference.cs
@@ -84,7 +84,7 @@ public class Spdx2JsonDeserializeExternalDocumentReference
         var externalDocumentReferences = Spdx2JsonDeserializer.DeserializeExternalDocumentReferences(json);
 
         // Assert: Verify the deserialized array has the expected number of references and their properties
-        Assert.AreEqual(1, externalDocumentReferences.Length);
+        Assert.HasCount(1, externalDocumentReferences);
         Assert.AreEqual("DocumentRef-1", externalDocumentReferences[0].ExternalDocumentId);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, externalDocumentReferences[0].Checksum.Algorithm);
         Assert.AreEqual("d6a770ba38583ed4bb4525bd96e50461655d2759", externalDocumentReferences[0].Checksum.Value);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeExternalReference.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeExternalReference.cs
@@ -84,7 +84,7 @@ public class Spdx2JsonDeserializeExternalReference
         var references = Spdx2JsonDeserializer.DeserializeExternalReferences(json);
 
         // Assert: Verify the deserialized array has the expected number of references and their properties
-        Assert.AreEqual(2, references.Length);
+        Assert.HasCount(2, references);
         Assert.AreEqual("This is just an example", references[0].Comment);
         Assert.AreEqual("cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*", references[0].Locator);
         Assert.AreEqual("cpe23Type", references[0].Type);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeExtractedLicensingInfo.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeExtractedLicensingInfo.cs
@@ -52,7 +52,7 @@ public class Spdx2JsonDeserializeExtractedLicensingInfo
         Assert.AreEqual("MIT", extractedLicensingInfo.LicenseId);
         Assert.AreEqual("This is the MIT license", extractedLicensingInfo.ExtractedText);
         Assert.AreEqual("MIT License", extractedLicensingInfo.Name);
-        Assert.AreEqual(1, extractedLicensingInfo.CrossReferences.Length);
+        Assert.HasCount(1, extractedLicensingInfo.CrossReferences);
         Assert.AreEqual("https://opensource.org/licenses/MIT", extractedLicensingInfo.CrossReferences[0]);
         Assert.AreEqual("This is a comment", extractedLicensingInfo.Comment);
     }
@@ -80,11 +80,11 @@ public class Spdx2JsonDeserializeExtractedLicensingInfo
         var extractedLicensingInfos = Spdx2JsonDeserializer.DeserializeExtractedLicensingInfos(json);
 
         // Assert: Verify the deserialized array has the expected properties
-        Assert.AreEqual(1, extractedLicensingInfos.Length);
+        Assert.HasCount(1, extractedLicensingInfos);
         Assert.AreEqual("MIT", extractedLicensingInfos[0].LicenseId);
         Assert.AreEqual("This is the MIT license", extractedLicensingInfos[0].ExtractedText);
         Assert.AreEqual("MIT License", extractedLicensingInfos[0].Name);
-        Assert.AreEqual(1, extractedLicensingInfos[0].CrossReferences.Length);
+        Assert.HasCount(1, extractedLicensingInfos[0].CrossReferences);
         Assert.AreEqual("https://opensource.org/licenses/MIT", extractedLicensingInfos[0].CrossReferences[0]);
         Assert.AreEqual("This is a comment", extractedLicensingInfos[0].Comment);
     }

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeFile.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeFile.cs
@@ -62,13 +62,13 @@ public class Spdx2JsonDeserializeFile
         // Assert: Verify the deserialized object has the expected properties
         Assert.AreEqual("SPDXRef-File", file.Id);
         Assert.AreEqual("src/DemaConsulting.SpdxModel/SpdxFile.cs", file.FileName);
-        Assert.AreEqual(1, file.FileTypes.Length);
+        Assert.HasCount(1, file.FileTypes);
         Assert.AreEqual(SpdxFileType.Source, file.FileTypes[0]);
-        Assert.AreEqual(1, file.Checksums.Length);
+        Assert.HasCount(1, file.Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, file.Checksums[0].Algorithm);
         Assert.AreEqual("2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", file.Checksums[0].Value);
         Assert.AreEqual("MIT", file.ConcludedLicense);
-        Assert.AreEqual(1, file.LicenseInfoInFiles.Length);
+        Assert.HasCount(1, file.LicenseInfoInFiles);
         Assert.AreEqual("MIT", file.LicenseInfoInFiles[0]);
         Assert.AreEqual("This is the MIT license", file.LicenseComments);
         Assert.AreEqual("This is a comment", file.Comment);
@@ -109,16 +109,16 @@ public class Spdx2JsonDeserializeFile
         var files = Spdx2JsonDeserializer.DeserializeFiles(json);
 
         // Assert: Verify the deserialized array has the expected properties
-        Assert.AreEqual(1, files.Length);
+        Assert.HasCount(1, files);
         Assert.AreEqual("SPDXRef-File", files[0].Id);
         Assert.AreEqual("src/DemaConsulting.SpdxModel/SpdxFile.cs", files[0].FileName);
-        Assert.AreEqual(1, files[0].FileTypes.Length);
+        Assert.HasCount(1, files[0].FileTypes);
         Assert.AreEqual(SpdxFileType.Source, files[0].FileTypes[0]);
-        Assert.AreEqual(1, files[0].Checksums.Length);
+        Assert.HasCount(1, files[0].Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, files[0].Checksums[0].Algorithm);
         Assert.AreEqual("2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", files[0].Checksums[0].Value);
         Assert.AreEqual("MIT", files[0].ConcludedLicense);
-        Assert.AreEqual(1, files[0].LicenseInfoInFiles.Length);
+        Assert.HasCount(1, files[0].LicenseInfoInFiles);
         Assert.AreEqual("MIT", files[0].LicenseInfoInFiles[0]);
         Assert.AreEqual("This is the MIT license", files[0].LicenseComments);
         Assert.AreEqual("This is a comment", files[0].Comment);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializePackage.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializePackage.cs
@@ -92,17 +92,17 @@ public class Spdx2JsonDeserializePackage
 
         // Assert: Verify the deserialized object has the expected properties
         Assert.AreEqual("SPDXRef-Package", package.Id);
-        Assert.AreEqual(1, package.Annotations.Length);
+        Assert.HasCount(1, package.Annotations);
         Assert.AreEqual("2011-01-29T18:30:22Z", package.Annotations[0].Date);
         Assert.AreEqual(SpdxAnnotationType.Other, package.Annotations[0].Type);
         Assert.AreEqual("Person: Package Commenter", package.Annotations[0].Annotator);
         Assert.AreEqual("Package level annotation", package.Annotations[0].Comment);
-        Assert.AreEqual(1, package.AttributionText.Length);
+        Assert.HasCount(1, package.AttributionText);
         Assert.AreEqual(
             "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.",
             package.AttributionText[0]);
         Assert.AreEqual("2011-01-29T18:30:22Z", package.BuiltDate);
-        Assert.AreEqual(3, package.Checksums.Length);
+        Assert.HasCount(3, package.Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Md5, package.Checksums[0].Algorithm);
         Assert.AreEqual("624c1abb3664f4b35547e7c73864ad24", package.Checksums[0].Value);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, package.Checksums[1].Algorithm);
@@ -114,7 +114,7 @@ public class Spdx2JsonDeserializePackage
             "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
             package.Description);
         Assert.AreEqual("http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz", package.DownloadLocation);
-        Assert.AreEqual(1, package.ExternalReferences.Length);
+        Assert.HasCount(1, package.ExternalReferences);
         Assert.AreEqual(SpdxReferenceCategory.Security, package.ExternalReferences[0].Category);
         Assert.AreEqual("cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
             package.ExternalReferences[0].Locator);
@@ -186,19 +186,19 @@ public class Spdx2JsonDeserializePackage
         var packages = Spdx2JsonDeserializer.DeserializePackages(json);
 
         // Assert: Verify the deserialized array has the expected number of packages and their properties
-        Assert.AreEqual(1, packages.Length);
+        Assert.HasCount(1, packages);
         Assert.AreEqual("SPDXRef-Package", packages[0].Id);
-        Assert.AreEqual(1, packages[0].Annotations.Length);
+        Assert.HasCount(1, packages[0].Annotations);
         Assert.AreEqual("2011-01-29T18:30:22Z", packages[0].Annotations[0].Date);
         Assert.AreEqual(SpdxAnnotationType.Other, packages[0].Annotations[0].Type);
         Assert.AreEqual("Person: Package Commenter", packages[0].Annotations[0].Annotator);
         Assert.AreEqual("Package level annotation", packages[0].Annotations[0].Comment);
-        Assert.AreEqual(1, packages[0].AttributionText.Length);
+        Assert.HasCount(1, packages[0].AttributionText);
         Assert.AreEqual(
             "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.",
             packages[0].AttributionText[0]);
         Assert.AreEqual("2011-01-29T18:30:22Z", packages[0].BuiltDate);
-        Assert.AreEqual(3, packages[0].Checksums.Length);
+        Assert.HasCount(3, packages[0].Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Md5, packages[0].Checksums[0].Algorithm);
         Assert.AreEqual("624c1abb3664f4b35547e7c73864ad24", packages[0].Checksums[0].Value);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, packages[0].Checksums[1].Algorithm);
@@ -211,7 +211,7 @@ public class Spdx2JsonDeserializePackage
             "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
             packages[0].Description);
         Assert.AreEqual("http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz", packages[0].DownloadLocation);
-        Assert.AreEqual(1, packages[0].ExternalReferences.Length);
+        Assert.HasCount(1, packages[0].ExternalReferences);
         Assert.AreEqual(SpdxReferenceCategory.Security, packages[0].ExternalReferences[0].Category);
         Assert.AreEqual("cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
             packages[0].ExternalReferences[0].Locator);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializePackageVerificationCode.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializePackageVerificationCode.cs
@@ -52,7 +52,7 @@ public class Spdx2JsonDeserializePackageVerificationCode
 
         // Assert: Verify the deserialized object has the expected properties
         Assert.AreEqual("d3b07384d113edec49eaa6238ad5ff00", packageVerificationCode.Value);
-        Assert.AreEqual(2, packageVerificationCode.ExcludedFiles.Length);
+        Assert.HasCount(2, packageVerificationCode.ExcludedFiles);
         Assert.AreEqual("file1.txt", packageVerificationCode.ExcludedFiles[0]);
         Assert.AreEqual("file2.txt", packageVerificationCode.ExcludedFiles[1]);
     }

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeRelationship.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeRelationship.cs
@@ -83,7 +83,7 @@ public class Spdx2JsonDeserializeRelationship
         var relationships = Spdx2JsonDeserializer.DeserializeRelationships(json);
 
         // Assert: Verify the deserialized objects have the expected properties
-        Assert.AreEqual(2, relationships.Length);
+        Assert.HasCount(2, relationships);
         Assert.AreEqual("SPDXRef-DOCUMENT", relationships[0].Id);
         Assert.AreEqual("SPDXRef-Package", relationships[0].RelatedSpdxElement);
         Assert.AreEqual(SpdxRelationshipType.Describes, relationships[0].RelationshipType);

--- a/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeSnippet.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/IO/Spdx2JsonDeserializeSnippet.cs
@@ -95,7 +95,7 @@ public class Spdx2JsonDeserializeSnippet
             "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
             snippet.LicenseComments);
         Assert.AreEqual("GPL-2.0-only", snippet.ConcludedLicense);
-        Assert.AreEqual(1, snippet.LicenseInfoInSnippet.Length);
+        Assert.HasCount(1, snippet.LicenseInfoInSnippet);
         Assert.AreEqual("GPL-2.0-only", snippet.LicenseInfoInSnippet[0]);
         Assert.AreEqual("from linux kernel", snippet.Name);
         Assert.AreEqual(420, snippet.SnippetByteEnd);
@@ -165,7 +165,7 @@ public class Spdx2JsonDeserializeSnippet
         var snippets = Spdx2JsonDeserializer.DeserializeSnippets(json);
 
         // Assert: Verify the deserialized array has the expected properties
-        Assert.AreEqual(1, snippets.Length);
+        Assert.HasCount(1, snippets);
         Assert.AreEqual("SPDXRef-Snippet", snippets[0].Id);
         Assert.AreEqual(
             "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
@@ -175,7 +175,7 @@ public class Spdx2JsonDeserializeSnippet
             "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
             snippets[0].LicenseComments);
         Assert.AreEqual("GPL-2.0-only", snippets[0].ConcludedLicense);
-        Assert.AreEqual(1, snippets[0].LicenseInfoInSnippet.Length);
+        Assert.HasCount(1, snippets[0].LicenseInfoInSnippet);
         Assert.AreEqual("GPL-2.0-only", snippets[0].LicenseInfoInSnippet[0]);
         Assert.AreEqual("from linux kernel", snippets[0].Name);
         Assert.AreEqual(420, snippets[0].SnippetByteEnd);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxAnnotationTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxAnnotationTests.cs
@@ -142,7 +142,7 @@ public class SpdxAnnotationTests
             ]);
 
         // Assert: Verify the annotations array has correct information
-        Assert.AreEqual(2, annotations.Length);
+        Assert.HasCount(2, annotations);
         Assert.AreEqual("SPDXRef-Annotation1", annotations[0].Id);
         Assert.AreEqual("Person: Malcolm Nixon", annotations[0].Annotator);
         Assert.AreEqual("2024-05-28T01:30:00Z", annotations[0].Date);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxChecksumTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxChecksumTests.cs
@@ -126,7 +126,7 @@ public class SpdxChecksumTests
             ]);
 
         // Assert: Verify checksums contain the expected values
-        Assert.AreEqual(2, checksums.Length);
+        Assert.HasCount(2, checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, checksums[0].Algorithm);
         Assert.AreEqual("c2b4e1c67a2d28fced849ee1bb76e7391b93f125", checksums[0].Value);
         Assert.AreEqual(SpdxChecksumAlgorithm.Md5, checksums[1].Algorithm);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxCreationInformationTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxCreationInformationTests.cs
@@ -78,7 +78,7 @@ public class SpdxCreationInformationTests
             });
 
         // Assert: Verify the enhanced information
-        Assert.AreEqual(3, info.Creators.Length);
+        Assert.HasCount(3, info.Creators);
         Assert.AreEqual("Tool: LicenseFind-1.0", info.Creators[0]);
         Assert.AreEqual("Organization: ExampleCodeInspect ()", info.Creators[1]);
         Assert.AreEqual("Person: Jane Doe ()", info.Creators[2]);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxDocumentTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxDocumentTests.cs
@@ -77,7 +77,7 @@ public class SpdxDocumentTests
         var packages = document.GetRootPackages();
 
         // Assert: Verify the correct root packages are returned
-        Assert.AreEqual(2, packages.Length);
+        Assert.HasCount(2, packages);
         Assert.IsTrue(Array.Exists(packages, p => p.Id == "SPDXRef-Package1"));
         Assert.IsTrue(Array.Exists(packages, p => p.Id == "SPDXRef-Package2"));
     }
@@ -300,7 +300,7 @@ public class SpdxDocumentTests
         doc.Validate(issues);
 
         // Ensure no validation issues
-        Assert.AreEqual(0, issues.Count);
+        Assert.IsEmpty(issues);
     }
 
     /// <summary>
@@ -343,7 +343,7 @@ public class SpdxDocumentTests
         doc.Validate(issues);
 
         // Assert: Verify duplicate ID reported
-        Assert.IsTrue(issues.Contains("Document Duplicate Element ID: SPDXRef-Package1"));
+        Assert.Contains("Document Duplicate Element ID: SPDXRef-Package1", issues);
     }
 
     /// <summary>
@@ -382,7 +382,7 @@ public class SpdxDocumentTests
         doc.Validate(issues);
 
         // Assert: Verify relationship to non-existent package reported
-        Assert.IsTrue(issues.Contains("Relationship Invalid Related SPDX Element Field: SPDXRef-Package2"));
+        Assert.Contains("Relationship Invalid Related SPDX Element Field: SPDXRef-Package2", issues);
     }
 
     /// <summary>
@@ -402,10 +402,10 @@ public class SpdxDocumentTests
         doc.Validate(issues, true);
 
         // Assert: Verify expected NTIA validation issues are reported.
-        Assert.IsTrue(issues.Contains("NTIA: Package Apache Commons Lang Missing Supplier"));
-        Assert.IsTrue(issues.Contains("NTIA: Package Apache Commons Lang Missing Version"));
-        Assert.IsTrue(issues.Contains("NTIA: Package Jena Missing Supplier"));
-        Assert.IsTrue(issues.Contains("NTIA: Package Saxon Missing Supplier"));
+        Assert.Contains("NTIA: Package Apache Commons Lang Missing Supplier", issues);
+        Assert.Contains("NTIA: Package Apache Commons Lang Missing Version", issues);
+        Assert.Contains("NTIA: Package Jena Missing Supplier", issues);
+        Assert.Contains("NTIA: Package Saxon Missing Supplier", issues);
     }
 
     /// <summary>

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxExternalDocumentReferenceTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxExternalDocumentReferenceTests.cs
@@ -159,7 +159,7 @@ public class SpdxExternalDocumentReferenceTests
             ]);
 
         // Assert: Verify the references array has correct information
-        Assert.AreEqual(2, references.Length);
+        Assert.HasCount(2, references);
         Assert.AreEqual("DocumentRef-spdx-tool-1.2", references[0].ExternalDocumentId);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, references[0].Checksum.Algorithm);
         Assert.AreEqual("d6a770ba38583ed4bb4525bd96e50461655d2759", references[0].Checksum.Value);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxExternalReferenceTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxExternalReferenceTests.cs
@@ -137,7 +137,7 @@ public class SpdxExternalReferenceTests
             ]);
 
         // Assert: Verify the references array has correct information
-        Assert.AreEqual(2, references.Length);
+        Assert.HasCount(2, references);
         Assert.AreEqual(SpdxReferenceCategory.Security, references[0].Category);
         Assert.AreEqual("cpe23Type", references[0].Type);
         Assert.AreEqual("cpe:2.3:a:company:product:0.0.0:*:*:*:*:*:*:*", references[0].Locator);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxExtractedLicensingInfoTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxExtractedLicensingInfoTests.cs
@@ -131,7 +131,7 @@ public class SpdxExtractedLicensingInfoTests
             ]);
 
         // Assert: Verify the infos array has correct information
-        Assert.AreEqual(2, infos.Length);
+        Assert.HasCount(2, infos);
         Assert.AreEqual("LicenseRef-1", infos[0].LicenseId);
         Assert.AreEqual("The CyberNeko Software License", infos[0].ExtractedText);
         Assert.AreEqual("Extracted from files", infos[0].Comment);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxFileTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxFileTests.cs
@@ -197,17 +197,17 @@ public class SpdxFileTests
             ]);
 
         // Assert: Verify the files array has been enhanced correctly
-        Assert.AreEqual(2, files.Length);
+        Assert.HasCount(2, files);
         Assert.AreEqual("SPDXRef-File1", files[0].Id);
         Assert.AreEqual("./file1.txt", files[0].FileName);
-        Assert.AreEqual(2, files[0].Checksums.Length);
+        Assert.HasCount(2, files[0].Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, files[0].Checksums[0].Algorithm);
         Assert.AreEqual("85ed0817af83a24ad8da68c2b5094de69833983c", files[0].Checksums[0].Value);
         Assert.AreEqual(SpdxChecksumAlgorithm.Md5, files[0].Checksums[1].Algorithm);
         Assert.AreEqual("624c1abb3664f4b35547e7c73864ad24", files[0].Checksums[1].Value);
         Assert.AreEqual("File 1", files[0].Comment);
         Assert.AreEqual("./file2.txt", files[1].FileName);
-        Assert.AreEqual(1, files[1].Checksums.Length);
+        Assert.HasCount(1, files[1].Checksums);
         Assert.AreEqual(SpdxChecksumAlgorithm.Sha1, files[1].Checksums[0].Algorithm);
         Assert.AreEqual("c2b4e1c67a2d28fced849ee1bb76e7391b93f125", files[1].Checksums[0].Value);
     }
@@ -273,7 +273,7 @@ public class SpdxFileTests
         spdxFile.Validate(issues);
 
         // Assert: Verify that the validation reports no issues.
-        Assert.AreEqual(0, issues.Count);
+        Assert.IsEmpty(issues);
     }
 
     /// <summary>

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxPackageTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxPackageTests.cs
@@ -172,7 +172,7 @@ public class SpdxPackageTests
             ]);
 
         // Assert: Verify the resulting packages are as expected.
-        Assert.AreEqual(2, packages.Length);
+        Assert.HasCount(2, packages);
         Assert.AreEqual("SPDXRef-Package1", packages[0].Id);
         Assert.AreEqual("DemaConsulting.SpdxModel", packages[0].Name);
         Assert.AreEqual("0.0.0", packages[0].Version);
@@ -225,6 +225,6 @@ public class SpdxPackageTests
         package.Validate(issues, null, true);
 
         // Assert: Verify that the validation reports no issues.
-        Assert.AreEqual(0, issues.Count);
+        Assert.IsEmpty(issues);
     }
 }

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxPackageVerificationCodeTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxPackageVerificationCodeTests.cs
@@ -112,7 +112,7 @@ public class SpdxPackageVerificationCodeTests
             });
 
         // Assert: Verify the excluded files and value are updated correctly
-        Assert.AreEqual(1, info.ExcludedFiles.Length);
+        Assert.HasCount(1, info.ExcludedFiles);
         Assert.AreEqual("./package.spdx", info.ExcludedFiles[0]);
         Assert.AreEqual("d6a770ba38583ed4bb4525bd96e50461655d2758", info.Value);
     }

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxRelationshipTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxRelationshipTests.cs
@@ -182,7 +182,7 @@ public class SpdxRelationshipTests
             ]);
 
         // Assert: Verify the relationships array has correct information
-        Assert.AreEqual(2, relationships.Length);
+        Assert.HasCount(2, relationships);
         Assert.AreEqual("SPDXRef-Package1", relationships[0].Id);
         Assert.AreEqual(SpdxRelationshipType.Contains, relationships[0].RelationshipType);
         Assert.AreEqual("SPDXRef-Package2", relationships[0].RelatedSpdxElement);

--- a/test/DemaConsulting.SpdxModel.Tests/SpdxSnippetTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/SpdxSnippetTests.cs
@@ -142,7 +142,7 @@ public class SpdxSnippetTests
             ]);
 
         // Assert: Check that the snippets array has been enhanced correctly
-        Assert.AreEqual(2, snippets.Length);
+        Assert.HasCount(2, snippets);
         Assert.AreEqual("SPDXRef-File1", snippets[0].SnippetFromFile);
         Assert.AreEqual(100, snippets[0].SnippetByteStart);
         Assert.AreEqual(200, snippets[0].SnippetByteEnd);
@@ -199,6 +199,6 @@ public class SpdxSnippetTests
         snippet.Validate(issues);
 
         // Assert: Verify that the validation reports no issues.
-        Assert.AreEqual(0, issues.Count);
+        Assert.IsEmpty(issues);
     }
 }

--- a/test/DemaConsulting.SpdxModel.Tests/Transforms/SpdxRelationshipsTests.cs
+++ b/test/DemaConsulting.SpdxModel.Tests/Transforms/SpdxRelationshipsTests.cs
@@ -71,7 +71,7 @@ public class SpdxRelationshipsTests
         // Assert: Verify the exception message and that no relationships were added
         Assert.AreEqual("Element SPDXRef-Package-Missing not found in SPDX document (Parameter 'relationship')",
             ex.Message);
-        Assert.AreEqual(0, document.Relationships.Length);
+        Assert.IsEmpty(document.Relationships);
     }
 
     /// <summary>
@@ -99,7 +99,7 @@ public class SpdxRelationshipsTests
         // Assert: Verify the exception message and that no relationships were added
         Assert.AreEqual("Element SPDXRef-Package-Missing not found in SPDX document (Parameter 'relationship')",
             ex.Message);
-        Assert.AreEqual(0, document.Relationships.Length);
+        Assert.IsEmpty(document.Relationships);
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ public class SpdxRelationshipsTests
             });
 
         // Assert: Verify the relationship was added correctly
-        Assert.AreEqual(1, document.Relationships.Length);
+        Assert.HasCount(1, document.Relationships);
         Assert.AreEqual("SPDXRef-Package-1", document.Relationships[0].Id);
         Assert.AreEqual("SPDXRef-Package-2", document.Relationships[0].RelatedSpdxElement);
         Assert.AreEqual(SpdxRelationshipType.DependsOn, document.Relationships[0].RelationshipType);
@@ -156,7 +156,7 @@ public class SpdxRelationshipsTests
             });
 
         // Assert: Verify the relationship was added only once
-        Assert.AreEqual(1, document.Relationships.Length);
+        Assert.HasCount(1, document.Relationships);
         Assert.AreEqual("SPDXRef-Package-1", document.Relationships[0].Id);
         Assert.AreEqual("SPDXRef-Package-2", document.Relationships[0].RelatedSpdxElement);
         Assert.AreEqual(SpdxRelationshipType.DependsOn, document.Relationships[0].RelationshipType);
@@ -184,7 +184,7 @@ public class SpdxRelationshipsTests
             ]);
 
         // Assert: Verify the relationship was added correctly
-        Assert.AreEqual(1, document.Relationships.Length);
+        Assert.HasCount(1, document.Relationships);
         Assert.AreEqual("SPDXRef-Package-1", document.Relationships[0].Id);
         Assert.AreEqual("SPDXRef-Package-2", document.Relationships[0].RelatedSpdxElement);
         Assert.AreEqual(SpdxRelationshipType.DependsOn, document.Relationships[0].RelationshipType);
@@ -218,7 +218,7 @@ public class SpdxRelationshipsTests
             ]);
 
         // Assert: Verify the relationship was added only once
-        Assert.AreEqual(1, document.Relationships.Length);
+        Assert.HasCount(1, document.Relationships);
         Assert.AreEqual("SPDXRef-Package-1", document.Relationships[0].Id);
         Assert.AreEqual("SPDXRef-Package-2", document.Relationships[0].RelatedSpdxElement);
         Assert.AreEqual(SpdxRelationshipType.DependsOn, document.Relationships[0].RelationshipType);
@@ -253,7 +253,7 @@ public class SpdxRelationshipsTests
             true);
 
         // Assert: Verify the relationship was replaced with the new type
-        Assert.AreEqual(1, document.Relationships.Length);
+        Assert.HasCount(1, document.Relationships);
         Assert.AreEqual("SPDXRef-Package-1", document.Relationships[0].Id);
         Assert.AreEqual("SPDXRef-Package-2", document.Relationships[0].RelatedSpdxElement);
         Assert.AreEqual(SpdxRelationshipType.BuildToolOf, document.Relationships[0].RelationshipType);


### PR DESCRIPTION
This PR multi-targets DotNet 8, 9, and 10. Additionally it updates project dependencies.